### PR TITLE
libonig: add a new RE library

### DIFF
--- a/make/libs/Config.in
+++ b/make/libs/Config.in
@@ -243,6 +243,7 @@ source make/libs/libffi/Config.in
 source make/libs/libfakefile/Config.in
 source make/libs/libctlmgr/Config.in
 source make/libs/libmultid/Config.in
+source make/libs/libonig/Config.in
 source make/libs/libtool/Config.in
 source make/lua/Config.in.libs
 source make/pcsc-lite/Config.in.libs

--- a/make/libs/external.in
+++ b/make/libs/external.in
@@ -62,6 +62,7 @@ source make/netpbm/external.in.libs
 source make/libs/nettle/external.in
 source make/ntfs/external.in.libs
 source make/libs/libogg/external.in
+source make/libs/libonig/external.in
 source make/libs/openjpeg/external.in
 source make/libs/openobex/external.in
 source make/libs/liboping/external.in

--- a/make/libs/libonig/Config.in
+++ b/make/libs/libonig/Config.in
@@ -1,0 +1,10 @@
+config FREETZ_LIB_libonig
+	bool "Oniguruma (libonig.so)"
+	default n
+	help
+		Oniguruma is a modern and flexible regular expressions library.
+		It encompasses features from different regular expression
+		implementations that traditionally exist in different languages.
+		It comes close to being a complete superset of all regular
+		expression features found in other regular expression
+		implementations.

--- a/make/libs/libonig/Makefile.in
+++ b/make/libs/libonig/Makefile.in
@@ -1,0 +1,3 @@
+ifeq ($(strip $(FREETZ_LIB_libonig)),y)
+LIBS+=libonig
+endif

--- a/make/libs/libonig/external.files
+++ b/make/libs/libonig/external.files
@@ -1,0 +1,1 @@
+[ "$EXTERNAL_FREETZ_LIB_libonig" == "y" ] && EXTERNAL_FILES+=" ${FREETZ_LIBRARY_DIR}/libonig.so.4.0.0"

--- a/make/libs/libonig/external.in
+++ b/make/libs/libonig/external.in
@@ -1,0 +1,7 @@
+config EXTERNAL_FREETZ_LIB_libonig
+	depends on EXTERNAL_ENABLED && FREETZ_LIB_libonig
+	bool "libonig"
+	default n
+	help
+		externals the following file(s):
+		 ${FREETZ_LIBRARY_DIR}/libonig.so.4.0.0

--- a/make/libs/libonig/libonig.mk
+++ b/make/libs/libonig/libonig.mk
@@ -1,0 +1,48 @@
+$(call PKG_INIT_LIB, a4020e75)
+$(PKG)_LIB_VERSION:=4.0.0
+$(PKG)_SOURCE:=$($(PKG)_VERSION).tar.xz
+$(PKG)_SITE:=git@https://github.com/kkos/oniguruma
+
+$(PKG)_LIBBASE:=libonig.so
+$(PKG)_LIBNAME:=$($(PKG)_LIBBASE).$($(PKG)_LIB_VERSION)
+$(PKG)_BINARY:=$($(PKG)_DIR)/src/.libs/$($(PKG)_LIBNAME)
+$(PKG)_STAGING_BINARY:=$(TARGET_TOOLCHAIN_STAGING_DIR)/usr/lib/$($(PKG)_LIBNAME)
+$(PKG)_TARGET_BINARY:=$($(PKG)_TARGET_DIR)/$($(PKG)_LIBNAME)
+
+$(PKG)_CONFIGURE_PRE_CMDS += ./autogen.sh ;
+
+$(PKG_SOURCE_DOWNLOAD)
+$(PKG_UNPACKED)
+$(PKG_CONFIGURED_CONFIGURE)
+
+$($(PKG)_BINARY): $($(PKG)_DIR)/.configured
+	$(SUBMAKE) -C $(LIBONIG_DIR)
+
+$($(PKG)_STAGING_BINARY): $($(PKG)_BINARY)
+	$(SUBMAKE) -C $(LIBONIG_DIR) \
+		DESTDIR="$(TARGET_TOOLCHAIN_STAGING_DIR)" \
+		install-strip
+	$(PKG_FIX_LIBTOOL_LA) \
+		$(TARGET_TOOLCHAIN_STAGING_DIR)/usr/lib/libonig.la \
+		$(TARGET_TOOLCHAIN_STAGING_DIR)/usr/lib/pkgconfig/oniguruma.pc \
+		$(TARGET_TOOLCHAIN_STAGING_DIR)/usr/bin/onig-config
+
+$($(PKG)_TARGET_BINARY): $($(PKG)_STAGING_BINARY)
+	$(INSTALL_LIBRARY_STRIP)
+
+$(pkg): $($(PKG)_STAGING_BINARY)
+
+$(pkg)-precompiled: $($(PKG)_TARGET_BINARY)
+
+$(pkg)-clean:
+	-$(SUBMAKE) -C $(LIBONIG_DIR) clean
+	$(RM) -r $(TARGET_TOOLCHAIN_STAGING_DIR)/usr/lib/libonig* \
+		$(TARGET_TOOLCHAIN_STAGING_DIR)/usr/include/oniguruma.h \
+		$(TARGET_TOOLCHAIN_STAGING_DIR)/usr/include/oniggnu.h \
+		$(TARGET_TOOLCHAIN_STAGING_DIR)/usr/include/onigposix.h \
+		$(TARGET_TOOLCHAIN_STAGING_DIR)/usr/bin/onig-config
+
+$(pkg)-uninstall:
+	$(RM) $(LIBONIG_TARGET_DIR)/$(LIBONIG_LIBBASE)*
+
+$(PKG_FINISH)

--- a/make/libs/libonig/patches/100-only_src.patch
+++ b/make/libs/libonig/patches/100-only_src.patch
@@ -1,0 +1,11 @@
+--- Makefile.am
++++ Makefile.am
+@@ -2,7 +2,7 @@
+
+ ACLOCAL_AMFLAGS = -I m4
+
+-SUBDIRS = src test sample
++SUBDIRS = src
+
+ EXTRA_DIST = oniguruma.pc.in HISTORY README_japanese README.md \
+	index.html index_ja.html \

--- a/make/libs/libonig/patches/101-include_and_lib.patch
+++ b/make/libs/libonig/patches/101-include_and_lib.patch
@@ -1,0 +1,28 @@
+--- onig-config.in
++++ onig-config.in
+@@ -30,6 +30,8 @@
+ prefix=@prefix@
+ exec_prefix=@exec_prefix@
+ is_set_exec_prefix=no
++includedir=@includedir@
++libdir=@libdir@
+
+ while test $# -gt 0; do
+   case "$1" in
+@@ -57,13 +59,13 @@
+       echo $exec_prefix
+       ;;
+     --cflags)
+-      if test @includedir@ != /usr/include ; then
+-        show_includedir=-I@includedir@
++      if test ${includedir} != /usr/include ; then
++        show_includedir=-I${includedir}
+       fi
+       echo $show_includedir
+       ;;
+     --libs)
+-      echo -L@libdir@ -lonig
++      echo -L${libdir} -lonig
+       ;;
+     --version)
+       echo $ONIG_VERSION

--- a/make/libs/libonig/patches/102-no_include_dir.patch
+++ b/make/libs/libonig/patches/102-no_include_dir.patch
@@ -1,0 +1,11 @@
+--- src/Makefile.am
++++ src/Makefile.am
+@@ -2,7 +2,7 @@
+ libname = libonig.la
+
+ AM_CFLAGS = -Wall
+-AM_CPPFLAGS = -I$(top_srcdir) -I$(includedir)
++AM_CPPFLAGS = -I$(top_srcdir)
+
+ include_HEADERS = oniguruma.h oniggnu.h onigposix.h
+ lib_LTLIBRARIES = $(libname)


### PR DESCRIPTION
From the source project:

Oniguruma is a modern and flexible regular expressions library,
published under BSD license.

It encompasses features from different regular expression
implementations that traditionally exist in different languages.

It comes close to being a complete superset of all regular
expression features found in other regular expression implementations.

https://github.com/kkos/oniguruma

This library is used by 'jq', a command-line JSON processor and (usually) by Ruby 1.9 (but below 2.0). 

That's why I've added the (optional) installation as DSO (for an image), even if no other package uses it nowadays ... and with no matter of the fact, that Ruby 1.9.3 (as it's provided by the Freetz package) is now out of maintenance (incl. security fixes) for more than three years (https://www.ruby-lang.org/en/downloads/branches/) and further usage of this version should be avoided (or at least a mighty warning should be attached to the package).