### PR TITLE
jq: add a new package

### DIFF
--- a/make/jq/Config.in
+++ b/make/jq/Config.in
@@ -1,0 +1,30 @@
+config FREETZ_PACKAGE_JQ
+	bool "jq - a command-line JSON processor"
+	default n
+	select FREETZ_LIB_libm if !FREETZ_PACKAGE_JQ_STATIC
+	select FREETZ_LIB_libonig if !FREETZ_PACKAGE_JQ_STATIC && FREETZ_PACKAGE_JQ_WITH_RE_SUPPORT
+	help
+		jq is a command-line JSON processor.
+
+		Because all files together need some room in the image
+		file (600-800 KB uncompressed), it's possible to move
+		them to an 'external' image, if it's activated at all.
+
+config FREETZ_PACKAGE_JQ_WITH_RE_SUPPORT
+	bool "include support for regular expresssions using Oniguruma"
+	depends on FREETZ_PACKAGE_JQ && FREETZ_SHOW_EXPERT
+	default y
+	help
+		Support for regular expressions adds 358 KB uncompressed
+		(about 105 KB compressed) to the final image (in the
+		binary and/or a shared library).
+		You may omit RE support here, if you'll not need it.
+
+config FREETZ_PACKAGE_JQ_STATIC
+	bool "Build static binary"
+	depends on FREETZ_PACKAGE_JQ && FREETZ_SHOW_EXPERT
+	default n
+	help
+		The resulting binary takes ~800 KB (~250 KB compressed)
+		on a MIPS-based architecture (-march=34kc).
+

--- a/make/jq/external.files
+++ b/make/jq/external.files
@@ -1,0 +1,1 @@
+[ "$EXTERNAL_FREETZ_PACKAGE_JQ" == "y" ] && EXTERNAL_FILES+=" /usr/bin/jq"

--- a/make/jq/external.in
+++ b/make/jq/external.in
@@ -1,0 +1,7 @@
+config EXTERNAL_FREETZ_PACKAGE_JQ
+	depends on EXTERNAL_ENABLED && FREETZ_PACKAGE_JQ
+	bool "jq"
+	default n
+	help
+		externals the following file(s):
+		 /usr/bin/jq

--- a/make/jq/jq.mk
+++ b/make/jq/jq.mk
@@ -1,0 +1,76 @@
+$(call PKG_INIT_BIN, a5b5cbefb8)
+$(PKG)_SOURCE:=$($(PKG)_VERSION).tar.xz
+$(PKG)_SITE:=git@https://github.com/stedolan/jq
+
+$(PKG)_BINARY_NAME := jq
+$(PKG)_BINARY := $($(PKG)_DIR)/$($(PKG)_BINARY_NAME)
+$(PKG)_TARGET_BINARY := $($(PKG)_DEST_DIR)/usr/bin/$($(PKG)_BINARY_NAME)
+
+$(PKG)_CFLAGS += -W -Wall -std=c99 -O2 -ffunction-sections -fdata-sections
+$(PKG)_LDFLAGS += -Wl,--gc-sections
+
+# we can check format arguments further, because patches are supplied to silence these warnings at the right places
+$(PKG)_CFLAGS += -Wformat=2
+
+# we need BSD_SOURCE for 'strdup' (it's heavily used in the original sources)
+$(PKG)_CFLAGS += -D_BSD_SOURCE
+
+# and we need XOPEN_SOURCE for 'fileno', too
+$(PKG)_CFLAGS += -D_XOPEN_SOURCE
+
+# errors are enforced on implicit function declarations, otherwise 'configure' doesn't detect absence of bessel
+# functions j0, j1, y0 and y1 - using pedantic error reporting isn't an alternative here, because there're other
+# incompatibilities in the original source
+$(PKG)_CFLAGS += -Werror=implicit-function-declaration
+
+# the configuration cache may declare j0, j1, y0 and y1 as present, if first check was made without error on
+# implicit function declarations (maybe without C99 enforced, too) - should overwrite the previous
+# TARGET_CONFIGURE_OPTIONS entry for 'cache-file' without side-effects (beside more efforts for 'configure')
+$(PKG)_CONFIGURE_OPTIONS += --cache-file=/dev/null
+
+$(PKG)_REBUILD_SUBOPTS += FREETZ_PACKAGE_JQ_STATIC
+$(PKG)_REBUILD_SUBOPTS += FREETZ_PACKAGE_JQ_WITH_RE_SUPPORT
+
+ifeq ($(strip $(FREETZ_PACKAGE_JQ_WITH_RE_SUPPORT)),y)
+$(PKG)_DEPENDS_ON += libonig
+else
+$(PKG)_CONFIGURE_ENV += WO_ONIGURUMA=1
+endif
+
+# we'll link 'libonig' and 'libm' dynamically or everything statically
+ifeq ($(strip $(FREETZ_PACKAGE_JQ_STATIC)),y)
+$(PKG)_CONFIGURE_OPTIONS += --enable-all-static
+else
+$(PKG)_CONFIGURE_PRE_CMDS += sed -i -r -e 's,-static-libtool-libs,-static,g' ./Makefile.in;
+endif
+
+$(PKG)_CONFIGURE_OPTIONS += --disable-silent-rules
+$(PKG)_CONFIGURE_OPTIONS += --disable-shared
+$(PKG)_CONFIGURE_OPTIONS += --disable-docs
+$(PKG)_CONFIGURE_OPTIONS += --disable-valgrind
+$(PKG)_CONFIGURE_OPTIONS += CFLAGS="$(TARGET_CFLAGS) $($(PKG)_CFLAGS)"
+
+$(PKG_SOURCE_DOWNLOAD)
+$(PKG_UNPACKED)
+$(PKG_CONFIGURED_CONFIGURE)
+
+$($(PKG)_BINARY): $($(PKG)_DIR)/.configured
+	$(SUBMAKE) -C $(JQ_DIR) \
+		CC="$(TARGET_CC)" \
+		CFLAGS="$(TARGET_CFLAGS) $(JQ_CFLAGS)" \
+		LDFLAGS="$(TARGET_LDFLAGS) $(JQ_LDFLAGS)"
+
+$($(PKG)_TARGET_BINARY): $($(PKG)_BINARY)
+	$(INSTALL_BINARY_STRIP)
+
+$(pkg):
+
+$(pkg)-precompiled: $($(PKG)_TARGET_BINARY)
+
+$(pkg)-clean:
+	$(SUBMAKE) -C $(JQ_DIR) clean
+
+$(pkg)-uninstall:
+	$(RM) $(JQ_TARGET_BINARY)
+
+$(PKG_FINISH)

--- a/make/jq/patches/100-bsd_and_xopen_from_cflags.patch
+++ b/make/jq/patches/100-bsd_and_xopen_from_cflags.patch
@@ -1,0 +1,9 @@
+--- builtin.c
++++ builtin.c
+@@ -1,6 +1,4 @@
+-#define _BSD_SOURCE
+ #define _GNU_SOURCE
+-#define _XOPEN_SOURCE
+ #include <sys/time.h>
+ #include <stdlib.h>
+ #include <stddef.h>

--- a/make/jq/patches/101-non_literal_format.patch
+++ b/make/jq/patches/101-non_literal_format.patch
@@ -1,0 +1,13 @@
+--- builtin.c
++++ builtin.c
+@@ -1188,7 +1188,10 @@
+   const char *fmt = jv_string_value(b);
+   size_t alloced = strlen(fmt) + 100;
+   char *buf = alloca(alloced);
++#pragma GCC diagnostic push
++#pragma GCC diagnostic ignored "-Wformat-nonliteral"
+   size_t n = strftime(buf, alloced, fmt, &tm);
++#pragma GCC diagnostic pop
+   jv_free(b);
+   /* POSIX doesn't provide errno values for strftime() failures; weird */
+   if (n == 0 || n > alloced)

--- a/make/jq/patches/103-without_oniguruma.patch
+++ b/make/jq/patches/103-without_oniguruma.patch
@@ -1,0 +1,19 @@
+--- configure
++++ configure
+@@ -13634,6 +13634,7 @@
+
+ # check for ONIGURUMA library
+ HAVE_ONIGURUMA=0
++if ! test "$WO_ONIGURUMA" = "1"; then
+ as_ac_Header=`$as_echo "ac_cv_header_"oniguruma.h"" | $as_tr_sh`
+ ac_fn_c_check_header_mongrel "$LINENO" ""oniguruma.h"" "$as_ac_Header" "$ac_includes_default"
+ if eval test \"x\$"$as_ac_Header"\" = x"yes"; then :
+@@ -13678,6 +13679,8 @@
+ fi
+
+ fi
++
++fi
+
+
+


### PR DESCRIPTION
jq is a lightweight and flexible command-line JSON processor.

- static linking option is only visible for 'experts'
- split C flags a bit with explanations
- RE support with Oniguruma is optional
- 'libonig' will be linked dynamically, if not the static binary
  has to be built
- both the binary and 'libonig.so' (if needed) may be moved to an
  'external' image

Note:

- do not use Freetz' cached configuration here, because it claims
  four non-existing bessel functions (from XSI_MATH) as present