### PR TITLE
Update busybox-host.mk

### DIFF
--- a/tools/make/busybox-host/busybox-host.mk
+++ b/tools/make/busybox-host/busybox-host.mk
@@ -1,7 +1,7 @@
 BUSYBOX_HOST_VERSION:=1.27.2
 BUSYBOX_HOST_SOURCE:=busybox-$(BUSYBOX_HOST_VERSION).tar.bz2
 BUSYBOX_HOST_SOURCE_MD5:=476186f4bab81781dab2369bfd42734e
-BUSYBOX_HOST_SITE:=http://www.busybox.net/downloads
+BUSYBOX_HOST_SITE:=https://web.archive.org/web/https://busybox.net/downloads
 
 BUSYBOX_HOST_MAKE_DIR:=$(TOOLS_DIR)/make/busybox-host
 BUSYBOX_HOST_DIR:=$(TOOLS_SOURCE_DIR)/busybox-$(BUSYBOX_HOST_VERSION)


### PR DESCRIPTION
http and https to busybox.net is not acessible, so the download fails.
provide newest archived version so the download works, from
https://web.archive.org/web/https://busybox.net/downloads