### PR TITLE
recover-eva: avoid abuse/malfunction with VR9 and GRX devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+### Please switch to the ```YourFritz``` branch (https://github.com/PeterPawn/freetz/tree/YourFritz), there you may find a summary of differences to the upstream project.

--- a/tools/recover-eva
+++ b/tools/recover-eva
@@ -126,19 +126,25 @@ $ipaddr = (@{$boxes[0]})[4];
 	# sub _PASV { shift->command("P\@SW")->response() == Net::FTP::CMD_OK }
 	sub _GETENV {
 		my $ftp = shift;
-		my ($ok, $name, $value);
+		my ($ok, $value, $rvalue, $rname, $line);
 
 		$ftp->command("GETENV",@_);
-		while(length($ok = $ftp->response()) < 1) {
-			my $line = $ftp->getline();
-			unless (defined($value)) {
+		if ($ftp->ok())
+		{
+			$line = $ftp->getline();
+			$value = "(missing)";
+			while ($line)
+			{
+				my $ec = substr($line, 0, 3);
+				return $value if ($ec eq "200");
+				return $value if ($ec eq "501"); # usually "ok()" should prevent us from here
 				chomp($line);
-				($name, $value) = split(/\s+/, $line, 2);
+				($rname, $rvalue) = split(/\s+/, $line, 2);
+				$value = $rvalue if ($rname); # no assignment on empty lines
+				$line = $ftp->getline();
 			}
 		}
-		$ftp->debug_print(0, "getenv: $value\n")
-			if $ftp->debug();
-		return $value;
+		return "(missing)";
 	}
 	sub getenv {
 		my $ftp = shift;
@@ -270,6 +276,9 @@ print "MTD1: $mtd1len bytes\n";
 print "MTD2: $mtd2len bytes\n";
 print "MTD3: $mtd3len bytes\n";
 print "MTD4: $mtd4len bytes\n";
+
+die "missing HWRevision" if ($hwrev eq "(missing)");
+die "wrong HWRevision" if ($hwrev >= 185);
 
 $ftp->hash(\*STDOUT, 64 * 1024);
 


### PR DESCRIPTION
@er13:
Ein schneller Hack (ich hasse Perl), um die Verwendung von "recover-eva" mit Boxen jenseits HWRevision 185 zu verhindern.

Es ist vielleicht möglich, mit diesem Script tatsächlich auch den Bootloader einer GRX-Box zu killen, wenn man diesem Thread folgen will (inzwischen sind es wohl schon zwei, was es wahrscheinlicher erscheinen läßt):

https://www.ip-phone-forum.de/threads/fritzbox-7590-bootloader-defekt-nach-flashversuch.299062/

Ich habe gar nicht erst untersucht, warum das Auslesen von Environment-Werten mit der vorherigen Version von "recover-eva" in einer Freetz-VM wohl nicht mehr sauber funktioniert ... aus dem Bauch heraus würde ich auf das Parsen der Server-Antwort in Net::Cmd tippen, wo wohl der Regex dafür fehlt, der über "parse_response" bereitgestellt werden müßte, was vermutlich nicht der Fall ist. Daß der Aufruf von "$ftp->ok()" auch für "501" (das ist das "Environment variable not set") ein "true" liefert, sollte jedenfalls eigentlich nicht passieren, weil alles ab "400" als Fehler anzusehen ist.

Das "GETENV" arbeitet jetzt zwar nicht mehr 1:1 wie in der alten Version (da nervt dann der Umgang mit leeren Perl-Variablen bei fehlenden Environment-Werten immer mit entsprechenden Fehlermeldungen, welche die Nutzer am Ende offenbar als "normal" ansehen - siehe Thread oben), aber solange die Werte von der Box kommen, sollte es auch für alte NOR- oder SPI-Modelle weiterhin funktionieren.

Wenn es irgendwelche Boxen jenseits der 185 gibt, bei denen die Installation über den Bootloader auch auf diesem Weg funktioniert, dann muß man das ggf. noch nachrüsten beim Vergleich ... die DOCSIS-Modelle gehören aber (auch wenn es dort funktioniert) eher nicht dazu, weil die ganz andere Partitionen verwenden und da hat "recover-eva" IMHO auch nichts verloren.

Sorry für die zusätzliche README.md - einfach ignorieren ... der Aufwand, jetzt einen Branch ohne die zu erzeugen, lohnt sicherlich nicht wirklich.

Ich sehe gerade, daß ich eine Debug-Ausgabe zuviel entsorgt habe ... denke aber gleichzeitig, daß die hier nicht wirklich wichtig wäre und der "Schutz" der Anwender (beim falschen Gerät) vor sich selbst dringender ist.