### PR TITLE
bash: add option to link it statically

### DIFF
--- a/make/bash/Config.in
+++ b/make/bash/Config.in
@@ -28,9 +28,6 @@ config FREETZ_PACKAGE_BASH_READLINE
 config FREETZ_PACKAGE_BASH_STATIC_LINK
 	bool "link bash shell as static binary"
 	depends on FREETZ_PACKAGE_BASH
-	select FREETZ_LIB_libncurses
-	select FREETZ_LIB_libreadline
-	select FREETZ_LIB_libhistory
 	default n
 	help
 		Include all needed libraries and build a single-file binary.

--- a/make/bash/Config.in
+++ b/make/bash/Config.in
@@ -25,6 +25,16 @@ config FREETZ_PACKAGE_BASH_READLINE
 	help
 		Enable command line editing and history. This feature needs ncurses and readline.
 
+config FREETZ_PACKAGE_BASH_STATIC_LINK
+	bool "link bash shell as static binary"
+	depends on FREETZ_PACKAGE_BASH
+	select FREETZ_LIB_libncurses
+	select FREETZ_LIB_libreadline
+	select FREETZ_LIB_libhistory
+	default n
+	help
+		Include all needed libraries and build a single-file binary.
+
 config FREETZ_PATCH_BASH_LOGIN_SHELL
 	bool "add bash to the list of login shells"
 	depends on FREETZ_PACKAGE_BASH

--- a/make/bash/bash.mk
+++ b/make/bash/bash.mk
@@ -22,7 +22,7 @@ $(PKG)_CONFIGURE_ENV += bash_cv_func_ctype_nonascii=no
 $(PKG)_CONFIGURE_ENV += bash_cv_func_sigsetjmp=present
 $(PKG)_CONFIGURE_ENV += bash_cv_func_strcoll_broken=no
 $(PKG)_CONFIGURE_ENV += bash_cv_getcwd_malloc=yes
-$(PKG)_CONFIGURE_ENV += bash_cv_getenv_redef=yes
+$(PKG)_CONFIGURE_ENV += bash_cv_getenv_redef=$(if $(FREETZ_PACKAGE_BASH_STATIC_LINK),no,yes)
 $(PKG)_CONFIGURE_ENV += bash_cv_job_control_missing=present
 $(PKG)_CONFIGURE_ENV += bash_cv_must_reinstall_sighandlers=no
 $(PKG)_CONFIGURE_ENV += bash_cv_opendir_not_robust=no
@@ -44,6 +44,7 @@ $(PKG)_CONFIGURE_OPTIONS += $(if $(FREETZ_PACKAGE_BASH_READLINE),,--disable-read
 $(PKG)_CONFIGURE_OPTIONS += $(if $(FREETZ_PACKAGE_BASH_READLINE),,--disable-history)
 $(PKG)_CONFIGURE_OPTIONS += $(if $(FREETZ_PACKAGE_BASH_READLINE),,--disable-bang-history)
 $(PKG)_CONFIGURE_OPTIONS += $(if $(FREETZ_PACKAGE_BASH_READLINE),--with-installed-readline,)
+$(PKG)_CONFIGURE_OPTIONS += $(if $(FREETZ_PACKAGE_BASH_STATIC_LINK),--enable-static-link,)
 
 $(PKG_SOURCE_DOWNLOAD)
 $(PKG_UNPACKED)


### PR DESCRIPTION
Maybe it's necessary to think again, how to reduce the number of options shown to the beginner?

You could add another dependency on "expert" settings - it's your choice.

Or reject the whole request ...