### PR TITLE
Update Download Url for fritz.box dir

### DIFF
--- a/tools/freetz_download
+++ b/tools/freetz_download
@@ -227,9 +227,9 @@ if [ -n "$URLs" ]; then
 			elif [ ${url:0:4} == "@AVM" ]; then
 				subpath=${url/@AVM\//}
 				sites[(( num_sites++ ))]=http://download.avm.de/fritzbox/$subpath
-				sites[(( num_sites++ ))]=http://download.avm.de/fritz.box/$subpath
+				sites[(( num_sites++ ))]=http://download.avm.de/archive/fritz.box/$subpath
 				sites[(( num_sites++ ))]=ftp://ftp.avm.de/fritzbox/$subpath
-				sites[(( num_sites++ ))]=ftp://ftp.avm.de/fritz.box/$subpath
+				sites[(( num_sites++ ))]=ftp://ftp.avm.de/archive/fritz.box/$subpath
 				sites[(( num_sites++ ))]=https://service.avm.de/downloads/$subpath
 				sites[(( num_sites++ ))]=http://avm.de/$subpath
 				sites[(( num_sites++ ))]=http://www.avm.de/de/Service/Service-Portale/$subpath


### PR DESCRIPTION
The fritz.box directory seems to be only exist in the archive subdir.