### PR TITLE
remove_mediasrv: fix patch file for 7390 devices

### DIFF
--- a/patches/scripts/500-remove_mediasrv.sh
+++ b/patches/scripts/500-remove_mediasrv.sh
@@ -1,5 +1,5 @@
 [ "$FREETZ_REMOVE_MEDIASRV" == "y" ] || \
-[ "$FREETZ_AVMPLUGINS_INTEGRATE" -a "$FREETZ_AVMPLUGINS_MEDIASRV" != "y" ] || \
+[ "$FREETZ_AVMPLUGINS_INTEGRATE" -a "$FREETZ_AVM_HAS_PLUGIN_MEDIASRV" = "y" -a "$FREETZ_AVMPLUGINS_MEDIASRV" != "y" ] || \
 return 0
 
 # if nas, mediaserv und samba are removed -> remove_nas deletes menu item Heimnetz > Speicher (NAS)


### PR DESCRIPTION
see this IPPF thread:

https://www.ip-phone-forum.de/threads/7390-06-85-14948-mediaserver.302469/

According to https://github.com/Freetz/freetz/blob/master/config/avm/features.in#L180
only very old 7270v1 versions had a plugin-based media server.

Removing the menu entry for this feature makes only sense, if the user explicitly
gave this order (via FREETZ_REMOVE_MEDIASRV - handled in line 1 of patch script) or
if he wants to integrate plugins and refuses to do this for the mediaserver plugin
(handled in line 2 and defined here:
https://github.com/Freetz/freetz/blob/master/config/ui/avm-plugins.in#L15).

Due to the used reverse logic (a met condition stops the script), the missing
~FREETZ_AVM_HAS_PLUGIN_MEDIASRV~ FREETZ_AVMPLUGINS_MEDIASRV symbol fulfills the "not equal 'y'" condition for each device, which isn't a FRITZ!Box 7270v1, at any time and only the presence of
FREETZ_AVMPLUGINS_INTEGRATE really controls the condition in line 2.

If FREETZ_AVMPLUGINS_INTEGRATE exists in combination with any other device (regardless
of its value), the media server pages get removed in every case, what's exactly the
problem reported by users.

To limit the second condition only to those devices, where the media server exists as a
plugin, FREETZ_AVM_HAS_PLUGIN_MEDIASRV may be tested, too. If it's not set to 'y', the
whole test statement will fail and the 'return 0' statement gets executed.