### PR TITLE
sqlite3: ignore optimizations for speed

### DIFF
--- a/make/sqlite/patches/900-no_speed_optimizations.patch
+++ b/make/sqlite/patches/900-no_speed_optimizations.patch
@@ -1,0 +1,14 @@
+--- Makefile.in
++++ Makefile.in
+@@ -251,9 +251,9 @@
+ BUILD_CFLAGS = @BUILD_CFLAGS@
+ CC = @CC@
+ CCDEPMODE = @CCDEPMODE@
+-CFLAGS = @CFLAGS@
++CFLAGS = $(patsubst -Ofast,-O2, @CFLAGS@)
+ CPP = @CPP@
+-CPPFLAGS = @CPPFLAGS@
++CPPFLAGS = $(patsubst -Ofast,-O2, @CPPFLAGS@)
+ CYGPATH_W = @CYGPATH_W@
+ DEBUG_FLAGS = @DEBUG_FLAGS@
+ DEFS = @DEFS@


### PR DESCRIPTION
Overrule any existing '-Ofast' flag with '-O2' - SQLite 3 will not compile with '-ffast-math' set, which is part of speed optimizations. Look at line 29485 in sqlite.c for further info.

This patch is usually not needed by many Freetz users, because "size optimization" is still the preferred (and default) style. But if a Freetz user sets the `-Ofast` option himself, `sqlite3` compilation fails without some countermeasures - this patch is **one** possible solution.