### PR TITLE
Update fwmod

### DIFF
--- a/fwmod
+++ b/fwmod
@@ -838,7 +838,7 @@ if [ "$DO_MOD" -gt 0 ]; then
 			[ "${REVISION:0:6}" == "export" ] && REVISION=""
 		fi
 	elif [ -d .git ]; then
-		REVISION="$(git rev-list --count HEAD)"
+		REVISION="branch-$(git status | sed -rn 's/.* Branch ([^/]*)$/\1/p')-$(git rev-list --count HEAD)"
 	fi
 	[ -n "$REVISION" ] && REVISION="-$REVISION"
 

--- a/fwmod
+++ b/fwmod
@@ -838,7 +838,7 @@ if [ "$DO_MOD" -gt 0 ]; then
 			[ "${REVISION:0:6}" == "export" ] && REVISION=""
 		fi
 	elif [ -d .git ]; then
-		REVISION="$(git log 2>/dev/null | sed -rn 's!.*git-svn-id.*\@([^ ]*).*!\1!p' | head -n1)"
+		REVISION="$(git rev-list --count HEAD)"
 	fi
 	[ -n "$REVISION" ] && REVISION="-$REVISION"
 


### PR DESCRIPTION
Versionierung für GIT geändert, damit eine fortlaufende Nummer (hier Anzahl der Commits im aktuellen lokalen build) ähnlich der SVN-Version im hash "freetz-devel-<nummer>" weiter angehängt werden kann. Bisher wurde die .git-svn-id ausgelesen, welche auf 15014 stehen blieb...