### PR TITLE
rc.mod: restore the order of execution at startup

### DIFF
--- a/patches/scripts/115-patch-ds_off.sh
+++ b/patches/scripts/115-patch-ds_off.sh
@@ -1,7 +1,7 @@
 if [ -e "${FILESYSTEM_MOD_DIR}/etc/init.d/rc.tail.sh" ]; then
 	rcfile="${FILESYSTEM_MOD_DIR}/etc/init.d/rc.tail.sh"
 
-cat << 'EOF' > "${FILESYSTEM_MOD_DIR}/etc/init.d/S99-zzz-rcmod"
+cat << 'EOF' > "${FILESYSTEM_MOD_DIR}/etc/init.d/E99-zzz-rcmod"
 # Emergency stop switch for execution of Freetz as a whole
 [ "$ds_off" == "y" ] || . /etc/init.d/rc.mod 2>&1 | tee /var/log/mod.log
 EOF


### PR DESCRIPTION
Starting with (at least) FRITZ!OS 7, the former file '/etc/init.d/S99-tail'
has been renamed as '/etc/init.d/E99-tail'.

As a result, the init script for Freetz's own modifications (rc.mod) is
not longer started AFTER the watchdog was terminated in
'/etc/init.d/rc.tail.sh', because 'S99-zzz-rcmod' gets executed first
and '/etc/init.d/E99-tail' (which includes 'rc.tail.sh') will not run,
until 'S99-zzz-rcmod' (which calls in turn 'rc.custom', if it exists)
was finished.

Depending on the duration of actions needed to initialize Freetz packages,
the bootup watchdog may get triggered, before it's deactivated in
'/etc/init.d/rc.tail.sh'.

The watchdog timeout from "init-start" is model-dependent - usually 120 or
240 seconds are used. If the original firmware sets the WDT to 120 seconds,
it's fairly simple to trigger this beast, if some Freetz packages have to be
initialized.

But this patch leads to a slightly change in the process structure during
initialization, too ... because all init-scripts with a first letter of
'E' are executed in a new shell instance, while 'S' scripts are included
into the current instance with the 'dot' command.

[ Hint: Look into file '/etc/init.d/rc.S' from vendor's firmware to get
an impression, how the init-scripts are called. ]

Therefore some side-effects are possible ... please double-check your
own init-scripts, if this patch was applied.

Another possible workaround would be a bigger timeout value, if you
prefer to run the 'S99-zzz-rcmod' script within the part of boot
process, that's protected by the watchdog.