### PR TITLE
Racecondition (udev vs. rc.mod) beheben (#2908)

### DIFF
--- a/make/inetd/files/root/bin/inetdctl
+++ b/make/inetd/files/root/bin/inetdctl
@@ -9,5 +9,10 @@ usage()
 # This script only controls AVM's ftpd and smbd but not Freetz samba/smbd.
 [ "$1" != "enable" -a "$1" != "disable" ] && usage
 [ "$2" != "ftpd" -a "$2" != "smbd" ] && usage
-[ -d /mod/etc/default.$2 ] && /mod/etc/init.d/rc.$2 inetd_$1
+if [ -d /mod/etc/default.$2 ]; then
+	/mod/etc/init.d/rc.$2 inetd_$1
+	[ -e /tmp/${2}_add_to_inetd_later ] && rm /tmp/${2}_add_to_inetd_later
+elif [ "$1" == "enable" ]; then
+	touch /tmp/${2}_add_to_inetd_later
+fi
 

--- a/make/mod/files/root/etc/init.d/rc.ftpd
+++ b/make/mod/files/root/etc/init.d/rc.ftpd
@@ -46,6 +46,7 @@ set_mode() {
 case $1 in
 	""|load)
 		modreg daemon -p avm ftpd
+		[ -e /tmp/ftpd_add_to_inetd_later ] && inetdctl enable ftpd
 		;;
 	unload)
 		modunreg daemon avm ftpd

--- a/make/mod/files/root/etc/init.d/rc.mod
+++ b/make/mod/files/root/etc/init.d/rc.mod
@@ -44,7 +44,7 @@ start() {
 		[ "$MOD_IPV6_FORWARD" == "yes" ] && echo 1 > /proc/sys/net/ipv6/conf/all/forwarding
 	fi
 
-	for pkg in crond telnetd webcfg dsld ftpd multid swap external websrv; do
+	for pkg in crond telnetd webcfg dsld ftpd multid swap external websrv smbd; do
 		local rc="/etc/init.d/rc.$pkg"
 		[ -x "$rc" ] && log "$($rc)"
 	done

--- a/make/mod/files/root/etc/init.d/rc.smbd
+++ b/make/mod/files/root/etc/init.d/rc.smbd
@@ -11,6 +11,9 @@ set_mode() {
 }
 
 case $1 in
+	""|load)
+		[ -e /tmp/smbd_add_to_inetd_later ] && inetdctl enable smbd
+		;;
 	inetd_enable)
 		set_mode inetd
 		;;
@@ -21,7 +24,7 @@ case $1 in
 		cat $STATUS_FILE 2>/dev/null
 		;;
 	*)
-		echo "Usage: $0 [inetd_enable|inetd_disable|status]" 1>&2
+		echo "Usage: $0 [load|inetd_enable|inetd_disable|status]" 1>&2
 		exit 1
 		;;
 esac


### PR DESCRIPTION
smbd und ftpd werden bei schon beim Booten angeschlossenen Speichermedien nicht in die inetd.conf eingetragen