### PR TITLE
ltrace: silence a warning due to a fall-through in a switch statement

### DIFF
--- a/make/ltrace/patches/900-uninitialized.patch
+++ b/make/ltrace/patches/900-uninitialized.patch
@@ -1,0 +1,15 @@
+--- expr.c
++++ expr.c
+@@ -236,8 +236,12 @@
+ 		if (expr_alloc_and_clone(&nlhs, node->lhs, node->own_lhs) < 0) {
+ 			if (node->kind == EXPR_OP_CALL2
+ 			    && node->u.call.own_rhs) {
++/* disable warning, nrhs is set due to previous fall-through */
++#pragma GCC diagnostic push
++#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+ 				expr_destroy(nrhs);
+ 				free(nrhs);
++#pragma GCC diagnostic pop
+ 				return -1;
+ 			}
+ 		}


### PR DESCRIPTION
Wegen eines "fall-through" in einem "switch"-Statement erkennt der Optimizer des C-Compilers hier eine möglicherweise nicht initialisierte Variable "nrhs", wenn man mit den Freetz-Vorgaben (-Wall, -Werror) kompiliert:

```
/bin/sh ./libtool  --tag=CC   --mode=compile /home/freetz/vr9_07.01_speed/toolchain/build/mips_gcc-5.5.0_uClibc-1.0.14-nptl_kernel-3.10/mips-linux-uclibc/bin/mips-linux-uclibc-gcc -DHAVE_CONFIG_H -I.  -DSYSCONFDIR=\"/etc\"  -DPKGDATADIR=\"/usr/share/ltrace\"    -I/home/freetz/vr9_07.01_speed/toolchain/build/mips_gcc-5.5.0_uClibc-1.0.14-nptl_kernel-3.10/mips-linux-uclibc/usr/include     -I./sysdeps/linux-gnu/mips      -I./sysdeps/linux-gnu   -I./sysdeps     -I.   -Wall -Wsign-compare -Wfloat-equal -Wformat-security -Werror -march=34kc -mtune=34kc -msoft-float -Ofast -pipe -Wa,--trap -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64 -MT expr.lo -MD -MP -MF .deps/expr.Tpo -c -o expr.lo expr.c

expr.c: In function 'expr_clone':
expr.c:240:5: error: 'nrhs' may be used uninitialized in this function [-Werror=maybe-uninitialized]
     free(nrhs);
     ^
cc1: all warnings being treated as errors
make[3]: *** [Makefile:746: expr.lo] Error 1
```

Nach Analyse des Quellcodes ist das ein "false positive" und kann - z.B. mit dem Patch in diesem Branch - ignoriert werden.

Angaben zur betroffenen GCC-Version, zum Kernel und zur uClibc-ng finden sich oben im `libtool`-Aufruf. In früheren Kombinationen trat das Problem (iirc) nicht auf.