### PR TITLE
busybox + uclibc-target: add setns() function and related applets

### DIFF
--- a/make/busybox/Config.in.busybox
+++ b/make/busybox/Config.in.busybox
@@ -4791,7 +4791,7 @@ config FREETZ_BUSYBOX_NSENTER
 	bool "nsenter"
 	default n
 	select FREETZ_BUSYBOX_PLATFORM_LINUX
-	depends on FREETZ_KERNEL_VERSION_3_10_MIN && FREETZ_AVM_UCLIBC_1_0_14
+	depends on FREETZ_KERNEL_VERSION_3_10_MIN && ( FREETZ_AVM_UCLIBC_1_0_14 || FREETZ_TARGET_UCLIBC_0_9_33 )
 	help
 	  Run program with namespaces of other processes.
 

--- a/make/busybox/generate.sh
+++ b/make/busybox/generate.sh
@@ -120,7 +120,7 @@ depends_on MDEV "FREETZ_KERNEL_VERSION_2_6_28_MIN"
 
 # setns syscall is available since kernel 3.0 (s. http://man7.org/linux/man-pages/man2/setns.2.html#VERSIONS)
 # and since uclibc-ng 1.0.1 (s. https://github.com/wbx-github/uclibc-ng/commit/5d5c77daae197b00f89ad1517ffb5a7a01a78cff)
-depends_on NSENTER "FREETZ_KERNEL_VERSION_3_10_MIN \&\& FREETZ_AVM_UCLIBC_1_0_14"
+depends_on NSENTER "FREETZ_KERNEL_VERSION_3_10_MIN \&\& ( FREETZ_AVM_UCLIBC_1_0_14 \|\| FREETZ_TARGET_UCLIBC_0_9_33 )"
 
 # fallocate applet requires posix_fallocate which is available (in Freetz) since uClibc-0.9.33
 depends_on FALLOCATE FREETZ_TARGET_UCLIBC_0_9_33

--- a/toolchain/make/target/uclibc/0.9.33.2/999-setns.upstream.patch
+++ b/toolchain/make/target/uclibc/0.9.33.2/999-setns.upstream.patch
@@ -1,0 +1,207 @@
+From 5d5c77daae197b00f89ad1517ffb5a7a01a78cff Mon Sep 17 00:00:00 2001
+From: Bernhard Reutner-Fischer <rep.dot.nop@gmail.com>
+Date: Tue, 17 Feb 2015 23:41:47 +0100
+Subject: libc: add setns()
+
+Signed-off-by: Bernhard Reutner-Fischer <rep.dot.nop@gmail.com>
+---
+ libc/sysdeps/linux/common/Makefile.in  |  1 +
+ libc/sysdeps/linux/common/bits/sched.h | 53 ++++++++++++++++++++++------------
+ libc/sysdeps/linux/common/setns.c      | 15 ++++++++++
+ libc/sysdeps/linux/common/stubs.c      |  4 +++
+ 4 files changed, 54 insertions(+), 19 deletions(-)
+ create mode 100644 libc/sysdeps/linux/common/setns.c
+
+diff --git a/libc/sysdeps/linux/common/Makefile.in b/libc/sysdeps/linux/common/Makefile.in
+index 9d41771..8ee956b 100644
+--- libc/sysdeps/linux/common/Makefile.in
++++ libc/sysdeps/linux/common/Makefile.in
+@@ -45,6 +45,7 @@ CSRC-$(UCLIBC_LINUX_SPECIFIC) += \
+ 	sendfile.c \
+ 	setfsgid.c \
+ 	setfsuid.c \
++	setns.c \
+ 	setresgid.c \
+ 	setresuid.c \
+ 	signalfd.c \
+diff --git a/libc/sysdeps/linux/common/bits/sched.h b/libc/sysdeps/linux/common/bits/sched.h
+index a5eb6ee..9d05314 100644
+--- libc/sysdeps/linux/common/bits/sched.h
++++ libc/sysdeps/linux/common/bits/sched.h
+@@ -1,7 +1,6 @@
+ /* Definitions of constants and data structure for POSIX 1003.1b-1993
+    scheduling interface.
+-   Copyright (C) 1996-1999,2001-2003,2005,2006,2007,2008
+-   Free Software Foundation, Inc.
++   Copyright (C) 1996-2015 Free Software Foundation, Inc.
+    This file is part of the GNU C Library.
+ 
+    The GNU C Library is free software; you can redistribute it and/or
+@@ -26,14 +25,17 @@
+ 
+ 
+ /* Scheduling algorithms.  */
+-#define SCHED_OTHER	0
+-#define SCHED_FIFO	1
+-#define SCHED_RR	2
++#define SCHED_OTHER		0
++#define SCHED_FIFO		1
++#define SCHED_RR		2
+ #ifdef __USE_GNU
+-# define SCHED_BATCH	3
++# define SCHED_BATCH		3
++# define SCHED_IDLE		5
++
++# define SCHED_RESET_ON_FORK	0x40000000
+ #endif
+ 
+-#ifdef __USE_MISC
++#ifdef __USE_GNU
+ /* Cloning flags.  */
+ # define CSIGNAL       0x000000ff /* Signal mask to be sent at exit.  */
+ # define CLONE_VM      0x00000100 /* Set if VM shared between processes.  */
+@@ -58,7 +60,6 @@
+ 				      force CLONE_PTRACE on this clone.  */
+ # define CLONE_CHILD_SETTID 0x01000000 /* Store TID in userlevel buffer in
+ 					  the child.  */
+-# define CLONE_STOPPED 0x02000000 /* Start in stopped state.  */
+ # define CLONE_NEWUTS	0x04000000	/* New utsname group.  */
+ # define CLONE_NEWIPC	0x08000000	/* New ipcs.  */
+ # define CLONE_NEWUSER	0x10000000	/* New user namespace.  */
+@@ -75,7 +76,7 @@ struct sched_param
+ 
+ __BEGIN_DECLS
+ 
+-#ifdef __USE_MISC
++#ifdef __USE_GNU
+ /* Clone current process.  */
+ extern int clone (int (*__fn) (void *__arg), void *__child_stack,
+ 		  int __flags, void *__arg, ...) __THROW;
+@@ -85,8 +86,12 @@ extern int unshare (int __flags) __THROW;
+ 
+ /* Get index of currently used CPU.  */
+ extern int sched_getcpu (void) __THROW;
++
++/* Switch process to namespace of type NSTYPE indicated by FD.  */
++extern int setns (int __fd, int __nstype) __THROW;
+ #endif
+ 
++
+ __END_DECLS
+ 
+ #endif	/* need schedparam */
+@@ -124,7 +129,11 @@ typedef struct
+ } cpu_set_t;
+ 
+ /* Access functions for CPU masks.  */
+-# define __CPU_ZERO_S(setsize, cpusetp) \
++# if __GNUC_PREREQ (2, 91)
++#  define __CPU_ZERO_S(setsize, cpusetp) \
++  do __builtin_memset (cpusetp, '\0', setsize); while (0)
++# else
++#  define __CPU_ZERO_S(setsize, cpusetp) \
+   do {									      \
+     size_t __i;								      \
+     size_t __imax = (setsize) / sizeof (__cpu_mask);			      \
+@@ -132,47 +141,53 @@ typedef struct
+     for (__i = 0; __i < __imax; ++__i)					      \
+       __bits[__i] = 0;							      \
+   } while (0)
++# endif
+ # define __CPU_SET_S(cpu, setsize, cpusetp) \
+   (__extension__							      \
+    ({ size_t __cpu = (cpu);						      \
+-      __cpu < 8 * (setsize)						      \
++      __cpu / 8 < (setsize)						      \
+       ? (((__cpu_mask *) ((cpusetp)->__bits))[__CPUELT (__cpu)]		      \
+ 	 |= __CPUMASK (__cpu))						      \
+       : 0; }))
+ # define __CPU_CLR_S(cpu, setsize, cpusetp) \
+   (__extension__							      \
+    ({ size_t __cpu = (cpu);						      \
+-      __cpu < 8 * (setsize)						      \
++      __cpu / 8 < (setsize)						      \
+       ? (((__cpu_mask *) ((cpusetp)->__bits))[__CPUELT (__cpu)]		      \
+ 	 &= ~__CPUMASK (__cpu))						      \
+       : 0; }))
+ # define __CPU_ISSET_S(cpu, setsize, cpusetp) \
+   (__extension__							      \
+    ({ size_t __cpu = (cpu);						      \
+-      __cpu < 8 * (setsize)						      \
+-      ? ((((__cpu_mask *) ((cpusetp)->__bits))[__CPUELT (__cpu)]	      \
++      __cpu / 8 < (setsize)						      \
++      ? ((((const __cpu_mask *) ((cpusetp)->__bits))[__CPUELT (__cpu)]	      \
+ 	  & __CPUMASK (__cpu))) != 0					      \
+       : 0; }))
+ 
+ # define __CPU_COUNT_S(setsize, cpusetp) \
+   __sched_cpucount (setsize, cpusetp)
+ 
+-# define __CPU_EQUAL_S(setsize, cpusetp1, cpusetp2) \
++# if __GNUC_PREREQ (2, 91)
++#  define __CPU_EQUAL_S(setsize, cpusetp1, cpusetp2) \
++  (__builtin_memcmp (cpusetp1, cpusetp2, setsize) == 0)
++# else
++#  define __CPU_EQUAL_S(setsize, cpusetp1, cpusetp2) \
+   (__extension__							      \
+-   ({ __cpu_mask *__arr1 = (cpusetp1)->__bits;				      \
+-      __cpu_mask *__arr2 = (cpusetp2)->__bits;				      \
++   ({ const __cpu_mask *__arr1 = (cpusetp1)->__bits;			      \
++      const __cpu_mask *__arr2 = (cpusetp2)->__bits;			      \
+       size_t __imax = (setsize) / sizeof (__cpu_mask);			      \
+       size_t __i;							      \
+       for (__i = 0; __i < __imax; ++__i)				      \
+ 	if (__arr1[__i] != __arr2[__i])					      \
+ 	  break;							      \
+       __i == __imax; }))
++# endif
+ 
+ # define __CPU_OP_S(setsize, destset, srcset1, srcset2, op) \
+   (__extension__							      \
+    ({ cpu_set_t *__dest = (destset);					      \
+-      __cpu_mask *__arr1 = (srcset1)->__bits;				      \
+-      __cpu_mask *__arr2 = (srcset2)->__bits;				      \
++      const __cpu_mask *__arr1 = (srcset1)->__bits;			      \
++      const __cpu_mask *__arr2 = (srcset2)->__bits;			      \
+       size_t __imax = (setsize) / sizeof (__cpu_mask);			      \
+       size_t __i;							      \
+       for (__i = 0; __i < __imax; ++__i)				      \
+diff --git a/libc/sysdeps/linux/common/setns.c b/libc/sysdeps/linux/common/setns.c
+new file mode 100644
+index 0000000..a697720
+--- /dev/null
++++ libc/sysdeps/linux/common/setns.c
+@@ -0,0 +1,15 @@
++/* vi: set sw=4 ts=4: */
++/*
++ * setns() for uClibc
++ *
++ * Copyright (C) 2015 Bernhard Reutner-Fischer <uclibc@uclibc.org>
++ *
++ * Licensed under the LGPL v2.1 or later, see the file COPYING.LIB in this tarball.
++ */
++
++#include <sys/syscall.h>
++#include <sched.h>
++
++#ifdef __NR_setns
++_syscall2(int, setns, int, fd, int, nstype)
++#endif
+diff --git a/libc/sysdeps/linux/common/stubs.c b/libc/sysdeps/linux/common/stubs.c
+index 57c4664..2c50307 100644
+--- libc/sysdeps/linux/common/stubs.c
++++ libc/sysdeps/linux/common/stubs.c
+@@ -346,6 +346,10 @@ make_stub(setfsgid)
+ make_stub(setfsuid)
+ #endif
+ 
++#if !defined __NR_setns && defined __UCLIBC_LINUX_SPECIFIC__
++make_stub(setns)
++#endif
++
+ #if !defined __NR_setresgid32 && !defined __NR_setresgid && defined __UCLIBC_LINUX_SPECIFIC__
+ make_stub(setresgid)
+ #endif
+-- 
+cgit v0.12
+


### PR DESCRIPTION
siehe IPPF-Thread:

https://www.ip-phone-forum.de/threads/busybox-1-27-2-neue-applets-bringen-neue-abh%C3%A4ngigkeiten-von-der-kernel-version.298282/

Über die Notwendigkeit von Namespaces auf der FRITZ!Box bestand keine Einigkeit, wie man im oben verlinkten Thread nachlesen kann.

Da es inzwischen eine "reale Anwendung" solcher Namespaces auf einer FRITZ!Box gibt (https://www.ip-phone-forum.de/threads/lost-in-translation-oder-wie-man-doch-noch-zu-einer-verst%C3%A4ndlichen-lua-seite-bei-avm-kommt.301428/ bzw. https://github.com/PeterPawn/YourFritz/blob/master/tools/get_page), mache ich aus dem Backport von "setns(I)" auf die uClibc 0.9.33 nun doch noch mal einen PR ... ein Gerät, was mit einem Kernel > 3.0 und der uClibc-0.9.33.2 arbeitet (und das vermutlich noch lange muß), wäre z.B. die FRITZ!Box 7412.

Da das Erstellen der betreffenden BusyBox-Applets bereits optional ist, sehe ich keine Notwendigkeit, das für die "setns()"-Funktion noch einmal gesondert umzusetzen, solange sie einwandfrei übersetzt wird. Der zusätzlich benötigte Platz in den DSO-Dateien ist praktisch zu vernachlässigen. Da, wo es tatsächlich eng ist (z.B. 7390), paßt dann schon der verwendete Kernel nicht mehr - siehe "generate.sh".