### PR TITLE
modfs_bootmanager: use new upstream version

### DIFF
--- a/tools/make/yourfritz-host/yourfritz-host.mk
+++ b/tools/make/yourfritz-host/yourfritz-host.mk
@@ -1,4 +1,4 @@
-YOURFRITZ_HOST_VERSION:=eaa8e3b2ba
+YOURFRITZ_HOST_VERSION:=2aa2e986ef
 YOURFRITZ_HOST_SOURCE:=yourfritz-$(YOURFRITZ_HOST_VERSION).tar.xz
 YOURFRITZ_HOST_SITE:=git_no_submodules@https://github.com/PeterPawn/YourFritz.git
 


### PR DESCRIPTION
Changes important for AVM's labor version 07.08:

This new version handles

- the different approach using version variables from `rc.conf` and
- the changed GUI implementation of AVM's reboot page, where `reboot.lua` doesn't contain HTML data any longer - instead a separate JavaScript file (`reboot.js`) is used and `reboot.lua` provides only JSON data to this module

The method of integration into AVM's files was changed, too ... for pre-07.08 and 07.08 versions; therefore the changed patch script is needed.

- solves https://github.com/Freetz/freetz/pull/77#issuecomment-464532379