### PR TITLE
fwmod: add support for alternative value locations of 07.08+ versions

### DIFF
--- a/fwmod
+++ b/fwmod
@@ -651,10 +651,16 @@ AVM_FW_LANGUAGE="$(sed -n 's/^language /_/p' ${FILESYSTEM_DIR}/etc/default.langu
 AVM_FW_LANGUAGE="${AVM_FW_LANGUAGE}$(for x in $(ls ${FILESYSTEM_DIR}/etc/htmltext_??.db 2>/dev/null| sed 's/.*_//g;s/\.db//g'); do [ "_$x" != "${AVM_FW_LANGUAGE}" ] && echo -en "-$x"; done; echo)" # other languages
 AVM_FW_MAJOR="$(sed -rn 's/^export CONFIG_VERSION_MAJOR="(.*)"/\1/p' ${FILESYSTEM_DIR}/etc/init.d/rc.conf | tail -n1)" # newer firmware
 [ -z "${AVM_FW_MAJOR}" ] && AVM_FW_MAJOR="$(sed -n 's/^HW=[0-9].*VERSION_MAJOR=//p' ${FILESYSTEM_DIR}/etc/init.d/rc.init)" # older firmware
-AVM_FW_VERSION="$(sed -n 's/^export FIRMWARE_VERSION=.*}[.]//p' ${FILESYSTEM_DIR}/etc/version)"
+if grep -q "^export FIRMWARE_" ${FILESYSTEM_DIR}/etc/version; then # pre-07.08 versions from AVM
+	AVM_FW_VERSION="$(sed -n 's/^export FIRMWARE_VERSION=.*}\.//p' ${FILESYSTEM_DIR}/etc/version)"
+	AVM_FW_REVISION="$(sed -n '/--project)$/{N;s/.*echo //p}' ${FILESYSTEM_DIR}/etc/version)"
+	AVM_FW_DATE="$(sed -rn 's/^export FIRMWARE_DATE="(.*)"/\1/p' ${FILESYSTEM_DIR}/etc/version)"
+else # starting with FRITZ!OS 07.08 another location was used for these values
+	AVM_FW_VERSION="$(sed -n 's/^export CONFIG_VERSION="\(.*\)"$/\1/p' ${FILESYSTEM_DIR}/etc/init.d/rc.conf)"
+	AVM_FW_REVISION="$(sed -n 's/^export CONFIG_BUILDNUMBER="\(.*\)"$/\1/p' ${FILESYSTEM_DIR}/etc/init.d/rc.conf)"
+	AVM_FW_DATE="$(date +"%d.%m.%Y %H:%M:%S" -d @$(stat -c %Y ${FILESYSTEM_DIR}/etc/version))"
+fi
 AVM_FW_LABOR="$(sed -rn 's/^export CONFIG_LABOR_ID_NAME="(.*)"/-\1/p' ${FILESYSTEM_DIR}/etc/init.d/rc.conf)"
-AVM_FW_REVISION="$(sed -n '/--project)$/{N;s/.*echo //p}' ${FILESYSTEM_DIR}/etc/version)"
-AVM_FW_DATE="$(sed -rn 's/^export FIRMWARE_DATE="(.*)"/\1/p' ${FILESYSTEM_DIR}/etc/version)"
 echo1 -l "detected${FIRMWARE_MAIN} firmware ${AVM_FW_PRODUCT/ /-}${AVM_FW_LANGUAGE} ${AVM_FW_MAJOR}.${AVM_FW_VERSION}${AVM_FW_LABOR} rev${AVM_FW_REVISION} (${AVM_FW_DATE})\n"
 
 if [ "$DO_MOD" -gt 0 ]; then


### PR DESCRIPTION
Tested with `fwmod` for these versions:

- detected firmware 7490_de 113.07.01 rev61077 (10.09.2018 11:42:49)
- detected firmware 7490_de 113.07.08-BETA rev65776 (19.02.2019 11:30:33)

This patch needs a complementary change, because the firmware date is detected now using the time of last modification for `/etc/version` and Freetz should try to avoid future changes to this file (optionally done here: https://github.com/Freetz/freetz/blob/master/fwmod#L885) to prevent confusing values - or the modification time should be preserved/restored.

- solves #85

---
 
For some other reasons, the whole `FREETZ_MODIFY_AVM_VERSION` part should be avoided in the future. There are proven problems with update checks (via JUIS), if the build number uses a wrong format or value. See this IPPF post for details: https://www.ip-phone-forum.de/threads/fritz-box-6490-cable-fritz-os-07-00-vom-28-09-2018.300986/page-2#post-2300407

It's a known fact, that AVM uses (at least partly) regular expressions to parse data from a SOAP request for the JUIS, see this post: https://www.ip-phone-forum.de/threads/update-check-%C3%BCber-den-neuen-avm-service.287657/page-9#post-2256618

Even if a Freetz user usually doesn't want automatic updates to the FRITZ!OS firmware, the same service (with some info from the box) is used to detect and install new firmware for other AVM devices, e.g. DECT phones and smart-home accessoires: https://www.ip-phone-forum.de/threads/update-check-%C3%BCber-den-neuen-avm-service.287657/page-7#post-2238219

---

I'd plea for a change to `FREETZ_MODIFY_AVM_VERSION`, that prevents the use of this option for all versions greater or equal to FRITZ!OS 06.8x - it's a protection against hard to find problems, if AVM changes something in the JUIS implementation. Such changes are never published by AVM and each modification framework should try to avoid any change, which will affect the interaction with external services (as long as it's not the intended effect).

A pull request for such a change to FREETZ_MODIFY_AVM_VERSION will be provided soon and refer in its substantiation to this one here.