### PR TITLE
fwmod: completely remove MODIFY_AVM_VERSION

### DIFF
--- a/config/ui/freetz.in
+++ b/config/ui/freetz.in
@@ -162,25 +162,6 @@ menu "Additional image/box information"
 			from your image. But usualy it is not necessary: The size of FREETZ-Info
 			is very small (2-3 kByte).
 
-	config FREETZ_MODIFY_AVM_VERSION
-		bool "Add Freetz version to AVM version data"
-		depends on FREETZ_AVM_VERSION_06_2X_MAX
-		default n
-		help
-			Add or append freetz version string (e.g. freetz-devel or freetz-devel-8849M)
-			to AVM firmware version data stored in /etc/.subversion, /etc/version and some
-			other places within the firmware itself.
-
-			Note: AVM firmware version data is exchanged with AVMs firmware update server
-			during automatic firmware update checks and in some other situations.
-			Enable this if you dont care if AVM or your ISP are knowing that you're running
-			a box with customized firmware.
-
-			Disable this if you have trouble with your isp or plugin downloads from
-			AVM don't work.
-
-			Maybe you want to change this too: http://wehavemorefun.de/fritzbox/AVM-Dienste
-
 	config FREETZ_USER_DEFINED_COMMENT
 		string "User defined comment"
 		default ""

--- a/fwmod
+++ b/fwmod
@@ -885,20 +885,6 @@ if [ "$DO_MOD" -gt 0 ]; then
 	echo1 "setting freetz-version '${SUBVERSION}'"
 	echo "$SUBVERSION" > "${FILESYSTEM_MOD_DIR}/etc/.freetz-version"
 
-	if [ "$FREETZ_MODIFY_AVM_VERSION" == "y" ]; then
-		echo1 "setting AVM firmware subversion '${SUBVERSION}'"
-		echo "$SUBVERSION" > "${FILESYSTEM_MOD_DIR}/etc/.subversion"
-		sed -i -e "s/\export\ FIRMWARE_SUBVERSION=.*\$/export\ FIRMWARE_SUBVERSION=\"${SUBVERSION}\"/g" "${FILESYSTEM_MOD_DIR}/etc/version"
-
-		if [ ! -e "${FILESYSTEM_MOD_DIR}/etc/init.d/rc.init" ]; then
-			AVM_SUBVERSION=`grep "SUBVERSION=" "${FILESYSTEM_MOD_DIR}/etc/init.d/rc.conf" | sed -e "s/[^-0-9]//g"`
-			sed -i -e "s/SUBVERSION=\"$AVM_SUBVERSION\"/SUBVERSION=\"-$SUBVERSION\"/" "${FILESYSTEM_MOD_DIR}/etc/init.d/rc.conf"
-		fi
-
-		sed -i -e "s/<subversion>/${SUBVERSION}/g" "${FILESYSTEM_MOD_DIR}/usr/bin/system_status"
-		sed -i -e "s/<options>/${OPTIONS}/g" "${FILESYSTEM_MOD_DIR}/usr/bin/system_status"
-	fi
-
 	# Execute general patch scripts
 	for i in "${PATCHES_SCRIPTS_DIR}/"*.sh; do
 		[ -r "$i" ] || continue


### PR DESCRIPTION
As far as I know and if I remember correctly, AVM was using JUIS service since FRITZ!OS 06.6x - even if this assumption is wrong, it's a good point for a caesura in my opinion.

A substantiation for this proposal may be found in #118 - and in the middle of discourse in #99.