### PR TITLE
7270 kernel: Fix localver and syslog for debug messages

### DIFF
--- a/make/linux/configs/freetz/config-ur8-7270_04.86
+++ b/make/linux/configs/freetz/config-ur8-7270_04.86
@@ -1,7 +1,7 @@
 #
 # Automatically generated make config: don't edit
 # Linux kernel version: 2.6.19.2
-# Tue Oct 12 01:16:22 2010
+# Sat Mar  2 14:38:07 2019
 #
 CONFIG_MIPS=y
 
@@ -187,7 +187,7 @@ CONFIG_INIT_ENV_ARG_LIMIT=32
 # General setup
 #
 CONFIG_LOCALVERSION=""
-CONFIG_LOCALVERSION_AUTO=y
+# CONFIG_LOCALVERSION_AUTO is not set
 CONFIG_SWAP=y
 CONFIG_SYSVIPC=y
 # CONFIG_IPC_NS is not set


### PR DESCRIPTION
Commits 15080 and 15252 from Freetz-ng (by fda)

fixes #91