### PR TITLE
firmware.in: remove "experimental" status in menuconfig (4040-6820)

### DIFF
--- a/config/ui/firmware.in
+++ b/config/ui/firmware.in
@@ -72,7 +72,7 @@ choice
 
 	config FREETZ_TYPE_4040
 		select FREETZ_AVM_SOURCE_FOR_SYSTEM_TYPE_IPQ40xx
-		bool "4040 - EXPERIMENTAL"
+		bool "4040"
 
 	comment "Fon"
 
@@ -115,7 +115,7 @@ choice
 
 	config FREETZ_TYPE_6820
 		select FREETZ_AVM_SOURCE_FOR_SYSTEM_TYPE_QCA955x
-		bool "6820 - EXPERIMENTAL (status: unknown)"
+		bool "6820"
 
 	config FREETZ_TYPE_6840
 		select FREETZ_AVM_SOURCE_FOR_SYSTEM_TYPE_VR9


### PR DESCRIPTION
Remove "experimental" status from menuconfig for the 4040 and the 6820LTE box. Compile and productive stable running tested by myself.