### PR TITLE
Adding a patch to fix issue #147.

### DIFF
--- a/make/linux/patches/2.6.39.3.x86/989-no-error-unused-parameter.patch
+++ b/make/linux/patches/2.6.39.3.x86/989-no-error-unused-parameter.patch
@@ -1,0 +1,11 @@
+--- linux-2.6.39/drivers/net/avm_cpu_connect/Makefile
++++ linux-2.6.39/drivers/net/avm_cpu_connect/Makefile
+@@ -1,7 +1,7 @@
+ #
+ # Copyright (C) 2014 AVM GmbH <fritzbox_info@avm.de>
+ #
+-EXTRA_CFLAGS += -Wall -Wextra -Werror
++EXTRA_CFLAGS += -Wall -Wextra -Werror -Wno-error=unused-parameter
+ 
+ obj-$(CONFIG_AVM_CPU_CONNECT) += avm_cpu_connect_driver.o
+ 


### PR DESCRIPTION
This pull request is adding a patch for drivers/net/avm_cpu_connect/Makefile which adds the parameter "-Wno-error-unused-parameter" to fix a compile error #147.