### PR TITLE
Labor version bump for 4040/6890 LTE/7530

### DIFF
--- a/FIRMWARES
+++ b/FIRMWARES
@@ -66,7 +66,7 @@ Currently supported boxes and firmwares
 
 * Fritz!Box 4040
 	* 155.07.01 rev61489 (German & International)
-	* 155.07.08 rev67160 (Labor)
+	* 155.07.08 rev67481 (Labor)
 
 ====== Fritz!Box Fon (5xxx) ======
 
@@ -117,7 +117,7 @@ Currently supported boxes and firmwares
 * Fritz!Box 6890 LTE (EXPERIMENTAL)
 	* 162.06.87 rev59283 (German & International)
 	* 162.07.01 rev63542 (German & International)
-	* 162.07.08 rev67155 (Labor)
+	* 162.07.08 rev67492 (Labor)
 
 ====== Fritz!Box Fon WLAN (70xx) ======
 
@@ -266,7 +266,7 @@ Currently supported boxes and firmwares
 * Fritz!Box Fon WLAN 7530 (EXPERIMENTAL)
 	* 164.07.02 rev62311
 	* 164.07.02 rev62314 (International)
-	* 164.07.08 rev67157 (Labor)
+	* 164.07.08 rev67480 (Labor)
 
 * Fritz!Box Fon WLAN 7560
 	* 149.06.53 rev41227

--- a/config/mod/download.in
+++ b/config/mod/download.in
@@ -458,7 +458,7 @@ menu "Override options"
 		default "FRITZ.Box_4020.de-en-es-it-fr-pl.147.07.01.image"              if FREETZ_TYPE_FIRMWARE_FINAL && FREETZ_TYPE_4020 && FREETZ_TYPE_FIRMWARE_07_0X
 		#
 		default "FRITZ.Box_4040.de-en-es-it-fr-pl.155.07.01.image"              if FREETZ_TYPE_FIRMWARE_FINAL && FREETZ_TYPE_4040 && FREETZ_TYPE_FIRMWARE_07_0X
-		default "FRITZ.Box_4040-07.08-67160-LabBETA.image"                      if FREETZ_TYPE_FIRMWARE_LABOR_BETA && FREETZ_TYPE_4040
+		default "FRITZ.Box_4040-07.08-67481-LabBETA.image"                      if FREETZ_TYPE_FIRMWARE_LABOR_BETA && FREETZ_TYPE_4040
 		#
 		default "fritz.box_fon_5010.annexa.48.04.43.image"                      if FREETZ_TYPE_FIRMWARE_FINAL && FREETZ_TYPE_5010
 		#
@@ -494,7 +494,7 @@ menu "Override options"
 		#
 		default "FRITZ.Box_6890_LTE.en-de-es-it-fr-pl-nl.162.06.87.image"       if FREETZ_TYPE_FIRMWARE_FINAL && FREETZ_TYPE_6890 && FREETZ_TYPE_FIRMWARE_06_8X
 		default "FRITZ.Box_6890_LTE.en-de-es-it-fr-pl-nl.162.07.01.image"       if FREETZ_TYPE_FIRMWARE_FINAL && FREETZ_TYPE_6890 && FREETZ_TYPE_FIRMWARE_07_0X
-		default "FRITZ.Box_6890_LTE-07.08-67155-LabBETA.image"                  if FREETZ_TYPE_FIRMWARE_LABOR_BETA && FREETZ_TYPE_6890
+		default "FRITZ.Box_6890_LTE-07.08-67492-LabBETA.image"                  if FREETZ_TYPE_FIRMWARE_LABOR_BETA && FREETZ_TYPE_6890
 		#
 		default "fritz.box_fon_wlan_7050.14.04.33.image"                        if FREETZ_TYPE_FIRMWARE_FINAL && FREETZ_TYPE_7050
 		#
@@ -615,7 +615,7 @@ menu "Override options"
 		#
 		default "FRITZ.Box_7530.164.07.02.image"                                if FREETZ_TYPE_FIRMWARE_FINAL && FREETZ_TYPE_7530 && FREETZ_TYPE_LANG_DE && FREETZ_TYPE_FIRMWARE_07_0X
 		default "FRITZ.Box_7530.en-de-es-it-fr-pl-nl.164.07.02.image"           if FREETZ_TYPE_FIRMWARE_FINAL && FREETZ_TYPE_7530 && FREETZ_TYPE_LANG_EN && FREETZ_TYPE_FIRMWARE_07_0X
-		default "FRITZ.Box_7530-07.08-67157-LabBETA.image"                      if FREETZ_TYPE_FIRMWARE_LABOR_BETA && FREETZ_TYPE_7530
+		default "FRITZ.Box_7530-07.08-67480-LabBETA.image"                      if FREETZ_TYPE_FIRMWARE_LABOR_BETA && FREETZ_TYPE_7530
 		#
 		default "FRITZ.Box_7560.149.06.53.image"                                if FREETZ_TYPE_FIRMWARE_FINAL && FREETZ_TYPE_7560 && FREETZ_TYPE_LANG_DE && FREETZ_TYPE_FIRMWARE_06_5X
 		default "FRITZ.Box_7560.149.06.83.image"                                if FREETZ_TYPE_FIRMWARE_FINAL && FREETZ_TYPE_7560 && FREETZ_TYPE_LANG_DE && FREETZ_TYPE_FIRMWARE_06_8X
@@ -881,12 +881,12 @@ menu "Override options"
 		string "Downloaded container file"              	if FREETZ_DL_OVERRIDE
 		#
 		default "FRITZ.Repeater_1750E-Labor-07.08-67300.zip"	if FREETZ_TYPE_FIRMWARE_LABOR_BETA && FREETZ_TYPE_1750
-		default "fritzbox-4040-labor-67160.zip"			if FREETZ_TYPE_FIRMWARE_LABOR_BETA && FREETZ_TYPE_4040
+		default "fritzbox-4040-labor-67481.zip"			if FREETZ_TYPE_FIRMWARE_LABOR_BETA && FREETZ_TYPE_4040
 		default "fritzbox-labor-6490-67153.zip"			if FREETZ_TYPE_FIRMWARE_LABOR_BETA && FREETZ_TYPE_6490
 		default "fritzbox-labor-6590-67154.zip"			if FREETZ_TYPE_FIRMWARE_LABOR_BETA && FREETZ_TYPE_6590
-		default "fritzbox-labor_6890-67155.zip"			if FREETZ_TYPE_FIRMWARE_LABOR_BETA && FREETZ_TYPE_6890
+		default "fritzbox-labor_6890-67492.zip"			if FREETZ_TYPE_FIRMWARE_LABOR_BETA && FREETZ_TYPE_6890
 		default "fritzbox-7490-labor-67076.zip"			if FREETZ_TYPE_FIRMWARE_LABOR_BETA && FREETZ_TYPE_7490
-		default "fritzbox-labor_7530-67157.zip"			if FREETZ_TYPE_FIRMWARE_LABOR_BETA && FREETZ_TYPE_7530
+		default "fritzbox-labor_7530-67480.zip"			if FREETZ_TYPE_FIRMWARE_LABOR_BETA && FREETZ_TYPE_7530
 		default "fritzbox-7560-Labor-67369.zip"			if FREETZ_TYPE_FIRMWARE_LABOR_BETA && FREETZ_TYPE_7560
 		default "fritzbox-7580-labor-67297.zip"			if FREETZ_TYPE_FIRMWARE_LABOR_BETA && FREETZ_TYPE_7580
 		default "fritzbox-7590-labor-67299.zip"			if FREETZ_TYPE_FIRMWARE_LABOR_BETA && FREETZ_TYPE_7590
@@ -897,12 +897,12 @@ menu "Override options"
 		string "MD5 checksum for container"             if FREETZ_DL_OVERRIDE
 		#
 		default "ee47db7070428e63ba6c2e586729f44a"      if FREETZ_TYPE_FIRMWARE_LABOR_BETA && FREETZ_TYPE_1750
-		default "54b119647f9fdde6053cab17d424ee57"      if FREETZ_TYPE_FIRMWARE_LABOR_BETA && FREETZ_TYPE_4040
+		default "36c4fbf95b3286297ac5dee0fde750f6"      if FREETZ_TYPE_FIRMWARE_LABOR_BETA && FREETZ_TYPE_4040
 		default "218d66b1207f2fc8a0dc8a61c7f6f7ea"      if FREETZ_TYPE_FIRMWARE_LABOR_BETA && FREETZ_TYPE_6490
 		default "2e24d72109fc9be21aebd8acb643a550"      if FREETZ_TYPE_FIRMWARE_LABOR_BETA && FREETZ_TYPE_6590
-		default "7cb6c7a9b25ecd919a2c7c5414513117"      if FREETZ_TYPE_FIRMWARE_LABOR_BETA && FREETZ_TYPE_6890
+		default "3d864ff3b84832add211f68022d6e10a"      if FREETZ_TYPE_FIRMWARE_LABOR_BETA && FREETZ_TYPE_6890
 		default "1d68b03f9545f8c0deb42a2cb2b471cc"      if FREETZ_TYPE_FIRMWARE_LABOR_BETA && FREETZ_TYPE_7490
-		default "25edee19e7eb20af944a8a6368c61195"      if FREETZ_TYPE_FIRMWARE_LABOR_BETA && FREETZ_TYPE_7530
+		default "128f089e32c8143e09bd9884fc9dabb1"      if FREETZ_TYPE_FIRMWARE_LABOR_BETA && FREETZ_TYPE_7530
 		default "6857a3d78e75caa5d6ad37035a76873e"      if FREETZ_TYPE_FIRMWARE_LABOR_BETA && FREETZ_TYPE_7560
 		default "0968fe49ef22c863a45996dbdf6c330b"      if FREETZ_TYPE_FIRMWARE_LABOR_BETA && FREETZ_TYPE_7580
 		default "37ee4b359705d941d5e975573b76d90f"      if FREETZ_TYPE_FIRMWARE_LABOR_BETA && FREETZ_TYPE_7590


### PR DESCRIPTION
Update to newest versions:

4040: 155.07.08 rev67481
6890 LTE: 162.07.08 rev67492
7530: 164.07.08 rev67480