### PR TITLE
dnsmasq: Avoid problems with DNSSEC after reboot

### DIFF
--- a/make/dnsmasq/files/root/etc/default.dnsmasq/dnsmasq_conf
+++ b/make/dnsmasq/files/root/etc/default.dnsmasq/dnsmasq_conf
@@ -53,6 +53,7 @@ fi
 if [ "$FREETZ_PACKAGE_DNSMASQ_WITH_DNSSEC" = "y" -a "$DNSMASQ_DNSSEC" = "yes" ]; then
 	[ -r /mod/etc/default.dnsmasq/trust-anchors.conf ] && echo "conf-file=/mod/etc/default.dnsmasq/trust-anchors.conf"
 	echo "dnssec"
+	echo "dnssec-timestamp=/etc/version"
 fi
 
 isdhcphost () {


### PR DESCRIPTION
When DNSSEC is enabled, disable its time checks until NTP set the
system time properly. Reuse /etc/version as reference file.

Closes #163 