### PR TITLE
mod: consider swapping may be disabled by kernel configuration

### DIFF
--- a/make/mod/files/root/etc/init.d/rc.swap
+++ b/make/mod/files/root/etc/init.d/rc.swap
@@ -58,6 +58,11 @@ autohelper() {
 	$1 >> /var/log/mod_swap.log
 }
 
+if ! [ -f /proc/swaps ]; then
+	[ "$1" = "status" ] && echo 'unsupported' && exit 0
+	exit 1	
+fi
+
 case $1 in
 	""|load)
 		modreg daemon -p mod swap

--- a/make/mod/files/root/usr/lib/cgi-bin/mod/conf/20-swap.sh
+++ b/make/mod/files/root/usr/lib/cgi-bin/mod/conf/20-swap.sh
@@ -1,3 +1,4 @@
+if [ -f /proc/swaps ]; then # only include content, if swap support is available - indentations are (intentionally) ignored here, the whole file gets excluded, if kernel lacks swap support
 sec_begin 'Swap'
 
 cgi_print_radiogroup_active \
@@ -17,3 +18,4 @@ EOF
 cgi_print_textline_p "swap_swappiness" "$MOD_SWAP_SWAPPINESS" 3/4 '<a href="http://lwn.net/Articles/83588/">$(lang de:"Swappiness" en:"Swappiness")</a> (0-100): '
 
 sec_end
+fi

--- a/make/mod/files/root/usr/lib/cgi-bin/mod/logs.cgi
+++ b/make/mod/files/root/usr/lib/cgi-bin/mod/logs.cgi
@@ -52,7 +52,7 @@ case "$3" in
 		do_log /var/log/mod_net.log
 		do_log /var/log/mod_voip.log
 		do_log /var/log/mod.log
-		do_log /var/log/mod_swap.log
+		[ -f /proc/swaps ] && do_log /var/log/mod_swap.log
 		do_log /var/log/rc_custom.log
 		do_log /var/log/debug_cfg.log
 		do_log /var/log/onlinechanged.log

--- a/make/mod/files/root/usr/lib/mww/page.d/conf/save_body.sh
+++ b/make/mod/files/root/usr/lib/mww/page.d/conf/save_body.sh
@@ -32,7 +32,7 @@ apply_changes() {
 			start_stop $startORstop websrv "$OLDSTATUS_websrv"
 			;;
 		mod)
-			start_stop $startORstop swap "$OLDSTATUS_swap"
+			[ -f /proc/swaps ] && start_stop $startORstop swap "$OLDSTATUS_swap"
 			# external
 			if [ -x /mod/etc/init.d/rc.external ]; then
 				if [ "$startORstop" == "stop" ]; then

--- a/make/mod/files/root/usr/mww/cgi-bin/status.d/20-memory.sh
+++ b/make/mod/files/root/usr/mww/cgi-bin/status.d/20-memory.sh
@@ -1,5 +1,6 @@
 
 has_swap() {
+	[ -f /proc/swaps ] || return 1
 	sed '1d' /proc/swaps | grep -q ''
 }
 


### PR DESCRIPTION
Some kernel configurations do not include swap support (at least not 'out of the box'), see #165.

Intended function after change(s):

`rc.swap`
- return exit code 1 for all actions beside 'status'
- return exit code 0 and 'unsupported' for action 'status'

`save_body.sh`
- only try status changes for swap 'daemon', if swap support exists at all

`20-swap.sh`
- don't generate any swap-related HTML elements

`logs.cgi`
- don't show swap-related log info, this missing info is - at the same time - the 'flag' for lack of support, there's no need to explicitly show an 'unsupported' info

`20-memory.sh`
- don't output virtual memory info, if swap support is missing from kernel

`libmodmount.sh`
- earliest possible cancellation of any 'start swap'-related action
- no errors issued, if swap support isn't provided
- issue a warning (kernel support missing), if a swap partition was found on an attached storage volume 

It's not necessary to change `usr/mww/cgi-bin/exec.d/create-swap.sh`, because it gets not called from `20-swap.sh`, if swapping is unsupported.
