### PR TITLE
 bind: version bump to 9.11.6-P1 and fixes

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -94,7 +94,7 @@ Latest changes:
     * apr 1.6.5
     * apr-util 1.6.1
     * bash 3.2.57
-    * bind 9.11.4
+    * bind 9.11.6-P1
     * bip 0.8.9
     * bird 1.6.4
     * CCID 1.4.18

--- a/make/bind/bind.mk
+++ b/make/bind/bind.mk
@@ -1,6 +1,6 @@
-$(call PKG_INIT_BIN, 9.11.4)
+$(call PKG_INIT_BIN, 9.11.6-P1)
 $(PKG)_SOURCE:=$(pkg)-$($(PKG)_VERSION).tar.gz
-$(PKG)_SOURCE_SHA256:=595070b031f869f8939656b5a5d11b121211967f15f6afeafa895df745279617
+$(PKG)_SOURCE_SHA256:=58ace2abb4d048b67abcdef0649ecd6cbd3b0652734a41a1d34f942d5500f8ef
 $(PKG)_SITE:=http://ftp.isc.org/isc/bind9/$($(PKG)_VERSION)
 
 $(PKG)_STARTLEVEL=40 # multid-wrapper may start it earlier!
@@ -19,7 +19,7 @@ $(eval $(call $(PKG)_DEFS,bin,nsupdate dig))
 
 $(PKG)_EXCLUDED+=$(if $(FREETZ_PACKAGE_BIND_NAMED),,usr/lib/bind usr/lib/cgi-bin/bind.cgi etc/default.bind etc/init.d/rc.bind)
 
-$(PKG)_CONFIGURE_PRE_CMDS += $(call PKG_PREVENT_RPATH_HARDCODING,./configure ./unit/atf-src/configure)
+$(PKG)_CONFIGURE_PRE_CMDS += $(call PKG_PREVENT_RPATH_HARDCODING,./configure) 
 
 $(PKG)_CONFIGURE_OPTIONS += BUILD_CC="$(HOSTCC)"
 $(PKG)_CONFIGURE_OPTIONS += --disable-shared
@@ -29,6 +29,7 @@ $(PKG)_CONFIGURE_OPTIONS += --enable-epoll=no
 $(PKG)_CONFIGURE_OPTIONS += --with-randomdev="/dev/random"
 $(PKG)_CONFIGURE_OPTIONS += --with-libtool
 $(PKG)_CONFIGURE_OPTIONS += --without-openssl
+$(PKG)_CONFIGURE_OPTIONS += --without-python
 $(PKG)_CONFIGURE_OPTIONS += --without-gssapi
 $(PKG)_CONFIGURE_OPTIONS += --disable-isc-spnego
 $(PKG)_CONFIGURE_OPTIONS += --without-pkcs11
@@ -47,9 +48,6 @@ $(PKG)_REBUILD_SUBOPTS += FREETZ_TARGET_IPV6_SUPPORT
 $(PKG)_MAKE_FLAGS += EXTRA_CFLAGS="-ffunction-sections -fdata-sections" EXTRA_BINARY_LDFLAGS="-Wl,--gc-sections"
 
 $(PKG)_EXPORT_LIB_DIR := $(FREETZ_BASE_DIR)/$(BIND_DIR)/_exportlib
-#$(PKG)_CONFIGURE_OPTIONS += --enable-exportlib
-#$(PKG)_CONFIGURE_OPTIONS += --with-export-includedir="$($(PKG)_EXPORT_LIB_DIR)/include"
-#$(PKG)_CONFIGURE_OPTIONS += --with-export-libdir="$($(PKG)_EXPORT_LIB_DIR)/lib"
 
 $(PKG_SOURCE_DOWNLOAD)
 $(PKG_UNPACKED)

--- a/make/bind/files/root/etc/init.d/rc.bind
+++ b/make/bind/files/root/etc/init.d/rc.bind
@@ -21,10 +21,10 @@ start() {
 	return 0
 }
 
-stop_checkmultid() {
+stop() {
 	[ "$nomultid" != "y" ] && /etc/init.d/rc.multid stop >/dev/null
-	#kill $(cat $PID_FILE) 2>/dev/null
-	modlib_stop $DAEMON_BIN 
+	kill $(cat $PID_FILE) 2>/dev/null
+	sleep 1
 	[ "$nomultid" != "y" ] && /etc/init.d/rc.multid start >/dev/null
 	return 0
 }
@@ -57,7 +57,7 @@ case $1 in
 		modlib_start
 		;;
 	stop)
-		stop_checkmultid
+		modlib_stop
 		;;
 	restart)
 		if [ "$FREETZ_AVMDAEMON_DISABLE_DNS" != "y" ]; then

--- a/make/bind/files/root/etc/init.d/rc.bind
+++ b/make/bind/files/root/etc/init.d/rc.bind
@@ -21,9 +21,10 @@ start() {
 	return 0
 }
 
-stop() {
+stop_checkmultid() {
 	[ "$nomultid" != "y" ] && /etc/init.d/rc.multid stop >/dev/null
-	kill $(cat $PID_FILE) 2>/dev/null
+	#kill $(cat $PID_FILE) 2>/dev/null
+	modlib_stop $DAEMON_BIN 
 	[ "$nomultid" != "y" ] && /etc/init.d/rc.multid start >/dev/null
 	return 0
 }
@@ -56,7 +57,7 @@ case $1 in
 		modlib_start
 		;;
 	stop)
-		modlib_stop
+		stop_checkmultid
 		;;
 	restart)
 		if [ "$FREETZ_AVMDAEMON_DISABLE_DNS" != "y" ]; then

--- a/make/bind/patches/020-isc_atomic_xadd.patch
+++ b/make/bind/patches/020-isc_atomic_xadd.patch
@@ -1,0 +1,112 @@
+--- bin/named/client.c
++++ bin/named/client.c
+@@ -402,12 +402,10 @@ tcpconn_detach(ns_client_t *client) {
+ static void
+ mark_tcp_active(ns_client_t *client, bool active) {
+ 	if (active && !client->tcpactive) {
+-		isc_atomic_xadd(&client->interface->ntcpactive, 1);
++		isc_refcount_increment0(&client->interface->ntcpactive, NULL);
+ 		client->tcpactive = active;
+ 	} else if (!active && client->tcpactive) {
+-		uint32_t old =
+-			isc_atomic_xadd(&client->interface->ntcpactive, -1);
+-		INSIST(old > 0);
++		isc_refcount_decrement(&client->interface->ntcpactive, NULL);
+ 		client->tcpactive = active;
+ 	}
+ }
+@@ -554,7 +552,7 @@ exit_check(ns_client_t *client) {
+ 		if (client->mortal && TCP_CLIENT(client) &&
+ 		    client->newstate != NS_CLIENTSTATE_FREED &&
+ 		    !ns_g_clienttest &&
+-		    isc_atomic_xadd(&client->interface->ntcpaccepting, 0) == 0)
++		    isc_refcount_current(&client->interface->ntcpaccepting) == 0)
+ 		{
+ 			/* Nobody else is accepting */
+ 			client->mortal = false;
+@@ -3326,7 +3324,6 @@ client_newconn(isc_task_t *task, isc_event_t *event) {
+ 	isc_result_t result;
+ 	ns_client_t *client = event->ev_arg;
+ 	isc_socket_newconnev_t *nevent = (isc_socket_newconnev_t *)event;
+-	uint32_t old;
+ 
+ 	REQUIRE(event->ev_type == ISC_SOCKEVENT_NEWCONN);
+ 	REQUIRE(NS_CLIENT_VALID(client));
+@@ -3346,8 +3343,7 @@ client_newconn(isc_task_t *task, isc_event_t *event) {
+ 	INSIST(client->naccepts == 1);
+ 	client->naccepts--;
+ 
+-	old = isc_atomic_xadd(&client->interface->ntcpaccepting, -1);
+-	INSIST(old > 0);
++	isc_refcount_decrement(&client->interface->ntcpaccepting, NULL);
+ 
+ 	/*
+ 	 * We must take ownership of the new socket before the exit
+@@ -3478,8 +3474,8 @@ client_accept(ns_client_t *client) {
+ 		 * quota is tcp-clients plus the number of listening
+ 		 * interfaces plus 1.)
+ 		 */
+-		exit = (isc_atomic_xadd(&client->interface->ntcpactive, 0) >
+-			(client->tcpactive ? 1 : 0));
++		exit = (isc_refcount_current(&client->interface->ntcpactive) >
++			(client->tcpactive ? 1U : 0U));
+ 		if (exit) {
+ 			client->newstate = NS_CLIENTSTATE_INACTIVE;
+ 			(void)exit_check(client);
+@@ -3537,7 +3533,7 @@ client_accept(ns_client_t *client) {
+ 	 * listening for connections itself to prevent the interface
+ 	 * going dead.
+ 	 */
+-	isc_atomic_xadd(&client->interface->ntcpaccepting, 1);
++	isc_refcount_increment0(&client->interface->ntcpaccepting, NULL);
+ }
+ 
+ static void
+--- bin/named/include/named/interfacemgr.h
++++ bin/named/include/named/interfacemgr.h
+@@ -45,6 +45,7 @@
+ #include <isc/magic.h>
+ #include <isc/mem.h>
+ #include <isc/socket.h>
++#include <isc/refcount.h>
+ 
+ #include <dns/result.h>
+ 
+@@ -75,11 +76,11 @@ struct ns_interface {
+ 						/*%< UDP dispatchers. */
+ 	isc_socket_t *		tcpsocket;	/*%< TCP socket. */
+ 	isc_dscp_t		dscp;		/*%< "listen-on" DSCP value */
+-	int32_t			ntcpaccepting;	/*%< Number of clients
++	isc_refcount_t		ntcpaccepting;	/*%< Number of clients
+ 						     ready to accept new
+ 						     TCP connections on this
+ 						     interface */
+-	int32_t			ntcpactive;	/*%< Number of clients
++	isc_refcount_t		ntcpactive;	/*%< Number of clients
+ 						     servicing TCP queries
+ 						     (whether accepting or
+ 						     connected) */
+--- bin/named/interfacemgr.c
++++ bin/named/interfacemgr.c
+@@ -386,8 +386,8 @@ ns_interface_create(ns_interfacemgr_t *mgr, isc_sockaddr_t *addr,
+ 	 * connections will be handled in parallel even though there is
+ 	 * only one client initially.
+ 	 */
+-	ifp->ntcpaccepting = 0;
+-	ifp->ntcpactive = 0;
++	isc_refcount_init(&ifp->ntcpaccepting, 0);
++	isc_refcount_init(&ifp->ntcpactive, 0);
+ 
+ 	ifp->nudpdispatch = 0;
+ 
+@@ -618,6 +618,9 @@ ns_interface_destroy(ns_interface_t *ifp) {
+ 
+ 	ns_interfacemgr_detach(&ifp->mgr);
+ 
++	isc_refcount_destroy(&ifp->ntcpactive);
++	isc_refcount_destroy(&ifp->ntcpaccepting);
++
+ 	ifp->magic = 0;
+ 	isc_mem_put(mctx, ifp, sizeof(*ifp));
+ }
+


### PR DESCRIPTION
* bump version to 9.11.6-P1
* included patch from https://gitlab.isc.org/isc-projects/bind9/commit/ef49780d30d3ddc5735cfc32561b678a634fa72f
  to fix compilation problem with uClibc
* fixed bug in rc.bind (stop() called by modlib_stop(), resulting in doubly attempted kill for 'named' process)
* removed obsolete stuff from bind.mk