### PR TITLE
bind: bump version to 9.11.6-P1 in menuconfig

### DIFF
--- a/make/bind/Config.in
+++ b/make/bind/Config.in
@@ -1,5 +1,5 @@
 config FREETZ_PACKAGE_BIND
-	bool "BIND 9.11.4"
+	bool "BIND 9.11.6-P1"
 	default n
 	help
 		BIND is an implementation of the Domain Name System (DNS) protocols.


### PR DESCRIPTION
Hier wurde vergessen die Version von Bind auch in der menuconfig anzupassen
#169