### PR TITLE
dnsmasq: change the behaviour of "use provider dns" in dnsmasq prefer…

### DIFF
--- a/make/dnsmasq/files/root/etc/default.dnsmasq/dnsmasq_conf
+++ b/make/dnsmasq/files/root/etc/default.dnsmasq/dnsmasq_conf
@@ -11,8 +11,7 @@ EOF
 grep -i "^resolv-file=" /tmp/flash/dnsmasq/dnsmasq.extra -q 2>/dev/null || echo "no-resolv"
 #add avm upstream-servers
 if [ "$DNSMASQ_AVM_DNS" = yes ]; then
-	echo "server=$(echo 'servercfg.dns1' | ar7cfgctl -s)"
-	echo "server=$(echo 'servercfg.dns2' | ar7cfgctl -s)"
+	echo "resolv-file=/var/tmp/avm-resolv.conf"
 fi
 #add own upstream-servers
 if [ -n "$DNSMASQ_UPSTREAM" ]; then

--- a/make/dnsmasq/files/root/usr/lib/cgi-bin/dnsmasq.cgi
+++ b/make/dnsmasq/files/root/usr/lib/cgi-bin/dnsmasq.cgi
@@ -69,13 +69,12 @@ cat << EOF
 <input type="hidden" name="avm_dns" value="no">
 <input id="avmdns1" type="checkbox" name="avm_dns" value="yes"$avm_dns_chk><label for="avmdns1"> $(lang de:"Durch AVM/Provider zugewiesene Upstream Nameserver nutzen." en:"Use the upstream nameservers of your provider/AVM.")</label>
 <br>$(lang de:"momentan: " en:"at the moment: ")
+<pre>
 EOF
-echo 'servercfg.dns1' | ar7cfgctl -s
+cat /var/tmp/avm-resolv.conf | cut -c 12- | sed 's/^/  /'
+
 cat << EOF
-$(lang de:" und " en:" and ")
-EOF
-echo 'servercfg.dns2' | ar7cfgctl -s
-cat << EOF
+</pre>
 </p>
 <p>$(lang de:"zus&auml;tzlich diese Upstream Nameserver nutzen (durch Leerzeichen getrennt)" en:"Use these upstream nameservers additionally (separated by space)"): <input type="text" name="upstream" size="55" maxlength="255" value="$(html "$DNSMASQ_UPSTREAM")"></p>
 <h2>$(lang de:"Zus&auml;tzliche Kommandozeilen-Optionen (f&uuml;r Experten)" en:"Additional command-line options (for experts)"):</h2>


### PR DESCRIPTION
…ences

bisher wurden, wenn der Haken bei "AVM/Provider DNS benutzen" gesetzt war, zwei Einträge mit "server=..." auf die internen IPv4 DNS-Weiterleitungen 192.168.180.1 und 192.168.180.2 gelegt.

Da mittlerweile auch IPv6-DNS-Server an einem nativen IPv6-Anschluss bzw an einem DS-LITE-Anschluss benötigt werden, habe ich mir gedacht, dass man grundsätzlich in der dnsmasq.conf auf den AVM-Resolver unter /var/tmp/avm-resolv.conf verweisen könnte.

Hier werden die DNS-Server, welche vom Provider übermittelt werden, also IPv4 UND IPv6, gespeichert und können so vom DNSMasq genutzt werden.

vgl. dnsmasq manpage http://www.thekelleys.org.uk/dnsmasq/docs/dnsmasq-man.html#--resolv-file