### PR TITLE
getdns: bump to 1.5.2

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -51,7 +51,7 @@ Latest changes:
     * decrypt FRITZ!OS configs v0.2 (renamed version of PeterPawn's script decode_passwords)
     * ISC dhcp 4.3.6-P1
     * E-MailRelay 1.9
-    * getdns 1.4.2
+    * getdns 1.5.2
     * gptfdisk 1.0.1
     * iksemel 1.5-git
     * iperf 3.6

--- a/make/getdns/Config.in
+++ b/make/getdns/Config.in
@@ -1,5 +1,5 @@
 config FREETZ_PACKAGE_GETDNS
-	bool "getdns 1.4.2 (binary only)"
+	bool "getdns 1.5.2 (binary only)"
 	select FREETZ_LIB_libpthread
 	#
 	select FREETZ_OPENSSL_VERSION_PROMPT

--- a/make/getdns/getdns.mk
+++ b/make/getdns/getdns.mk
@@ -1,7 +1,7 @@
-$(call PKG_INIT_BIN, 1.4.2)
+$(call PKG_INIT_BIN, 1.5.2)
 $(PKG)_SOURCE:=getdns-$($(PKG)_VERSION).tar.gz
-$(PKG)_SOURCE_SHA256:=1685b82dfe297cffc4bae08a773cdc88a3edf9a4e5a1ea27d8764bb5affc0e80
-$(PKG)_SITE:=https://getdnsapi.net/releases/getdns-1-4-2
+$(PKG)_SOURCE_SHA256:=1826a6a221ea9e9301f2c1f5d25f6f5588e841f08b967645bf50c53b970694c0
+$(PKG)_SITE:=https://getdnsapi.net/releases/getdns-$(subst .,-,$($(PKG)_VERSION))
 
 $(PKG)_BINARY:=$($(PKG)_DIR)/src/stubby
 $(PKG)_TARGET_BINARY:=$($(PKG)_DEST_DIR)/usr/bin/stubby

--- a/make/getdns/patches/010-fix_implicit_declaration.patch
+++ b/make/getdns/patches/010-fix_implicit_declaration.patch
@@ -9,7 +9,7 @@ Fixes
 
 --- configure
 +++ configure
-@@ -3963,7 +3963,7 @@
+@@ -4081,7 +4081,7 @@
  
  
  case "$host_os" in


### PR DESCRIPTION
- inspired by https://trac.boxmatrix.info/freetz-ng/changeset/15701/freetz-ng
- runtime tested