### PR TITLE
patches: modfs boot manager installation

### DIFF
--- a/patches/scripts/800-modfs_boot_manager.sh
+++ b/patches/scripts/800-modfs_boot_manager.sh
@@ -11,7 +11,8 @@ for oem in $(supported_brandings) all; do
 	echo2 "adding boot-manager front end to branding \"${oem}\""
 
 	TARGET_BRANDING="${oem}" \
-	TARGET_SYSTEM_VERSION="${AVM_FW_MAJOR}.${AVM_FW_VERSION}" \
+	TARGET_SYSTEM_VERSION="autodetect" \
+	TARGET_SYSTEM_VERSION_DETECTOR="${TOOLS_DIR}/yf/bootmanager/extract_version_values" \
 	TARGET_DIR="${FILESYSTEM_MOD_DIR}" \
 	TMP="$TEMPDIR" \
 	sh "${TOOLS_DIR}/yf/bootmanager/add_to_system_reboot.sh"

--- a/tools/make/yourfritz-host/yourfritz-host.mk
+++ b/tools/make/yourfritz-host/yourfritz-host.mk
@@ -1,4 +1,4 @@
-YOURFRITZ_HOST_VERSION:=50b40c96f3
+YOURFRITZ_HOST_VERSION:=2958e4ab9d
 YOURFRITZ_HOST_SOURCE:=yourfritz-$(YOURFRITZ_HOST_VERSION).tar.xz
 YOURFRITZ_HOST_SITE:=git_no_submodules@https://github.com/PeterPawn/YourFritz.git
 


### PR DESCRIPTION
Das ist **mein** Vorschlag zur vorläufigen/unmittelbaren Korrektur von #115 bei der Verwendung des Patch-Skripts im Rahmen von "fwmod_custom" bzw. bei anderen Aufrufen, wo die erforderlichen Variablen nicht gesetzt sind. Wenn jemand eine andere (oder gar bessere, wobei mich da dann wieder der "Bewertungsmaßstab" interessieren würde) Lösung hat, geht das für mich auch in Ordnung, solange daraus keine Forderungen für weitere Änderungen im YourFritz-Repo resultieren, die dann nur dazu dienen, diese andere Implementierung irgendwie möglich zu machen - so etwas bräuchte dann schon eine deutlich plausible Begründung.

Ich weiche hier doch noch einmal von meiner generell geänderten Haltung (bzgl. PRs von mir) ab, da es sich um eine Korrektur für einen früheren, inzwischen irgendwie auch zusammengemischten Vorschlag handelt.

Um das von Beginn an klarzustellen: Ja, meine 4-Wochen-Policy gilt auch hierfür bzw. in diesem Falle dann sogar für den Branch, auf dem der PR hier basiert. Da aber die Commits ohnehin auch das Löschen des Branches überleben (sie sind dann halt nur nicht länger über den Branch-Namen zu lokalisieren), verstehe ich das ebenfalls nicht als "Ultimatum", sondern nur als (obendrein angesagtes) "housekeeping".