### PR TITLE
Cacerts

### DIFF
--- a/make/cacerts/Config.in
+++ b/make/cacerts/Config.in
@@ -1,0 +1,19 @@
+config FREETZ_PACKAGE_CACERTS
+	bool "CA Certs"
+	default n
+	help
+		This package provides up-to-date ca-certs from curl.haxx.se
+
+config FREETZ_PACKAGE_CACERTS_FORCE_DOWNLOAD
+	bool "Force update on each build"
+	depends on FREETZ_PACKAGE_CACERTS
+	default y
+	help
+		Download the latest cacerts each time freetz is built.
+
+config FREETZ_CACERTS_DIR
+	string "Folder to place cacert.pem"
+	depends on FREETZ_PACKAGE_CACERTS
+	default "/etc/ssl/certs"
+	help
+		The location of cacerts.pem file.

--- a/make/cacerts/cacerts.mk
+++ b/make/cacerts/cacerts.mk
@@ -1,0 +1,23 @@
+$(call PKG_INIT_BIN, 0.1)
+$(PKG)_SOURCE:=cacert.pem
+$(PKG)_SITE:=https://curl.haxx.se/ca
+
+$(PKG)_TARGET_PATH:=/etc/ssl/certs/
+
+$(if $(FREETZ_PACKAGE_CACERTS_FORCE_DOWNLOAD),.PHONY: $(DL_DIR)/$($(PKG)_SOURCE))
+
+$(PKG_SOURCE_DOWNLOAD)
+
+$($(PKG)_DEST_DIR)$($(PKG)_TARGET_PATH): $(DL_DIR)/$($(PKG)_SOURCE)
+	$(INSTALL_FILE)
+
+$(pkg):
+
+$(pkg)-precompiled: $($(PKG)_DEST_DIR)$($(PKG)_TARGET_PATH)
+
+$(pkg)-clean:
+
+$(pkg)-uninstall:
+	$(RM) $($(PKG)_DEST_DIR)$($(PKG)_TARGET_PATH)
+
+$(PKG_FINISH)

--- a/make/curl/curl.mk
+++ b/make/curl/curl.mk
@@ -78,11 +78,7 @@ $(PKG)_CONFIGURE_OPTIONS += --without-gnutls
 $(PKG)_CONFIGURE_OPTIONS += --without-polarssl
 $(PKG)_CONFIGURE_OPTIONS += $(if $(FREETZ_LIB_libcurl_WITH_OPENSSL),--with-ssl="$(TARGET_TOOLCHAIN_STAGING_DIR)/usr",--without-ssl)
 $(PKG)_CONFIGURE_OPTIONS += $(if $(FREETZ_LIB_libcurl_WITH_MBEDTLS),--with-mbedtls="$(TARGET_TOOLCHAIN_STAGING_DIR)/usr",--without-mbedtls)
-<<<<<<< HEAD
 $(PKG)_CONFIGURE_OPTIONS += $(if $(FREETZ_PACKAGE_CACERTS),--with-ca-bundle=$(FREETZ_CACERTS_DIR)"/cacert.pem",--without-ca-bundle)
-=======
-$(PKG)_CONFIGURE_OPTIONS += $(if $(FREETZ_OPENSSL_CONFIG_DIR),--with-ca-bundle=$(FREETZ_CACERTS_DIR)"/cacert.pem",--without-ca-bundle)
->>>>>>> cf4ad616e41b234f2d60beefc930d744356495f6
 $(PKG)_CONFIGURE_OPTIONS += --without-gssapi
 $(PKG)_CONFIGURE_OPTIONS += --without-libidn
 $(PKG)_CONFIGURE_OPTIONS += --without-libmetalink

--- a/make/curl/curl.mk
+++ b/make/curl/curl.mk
@@ -78,7 +78,7 @@ $(PKG)_CONFIGURE_OPTIONS += --without-gnutls
 $(PKG)_CONFIGURE_OPTIONS += --without-polarssl
 $(PKG)_CONFIGURE_OPTIONS += $(if $(FREETZ_LIB_libcurl_WITH_OPENSSL),--with-ssl="$(TARGET_TOOLCHAIN_STAGING_DIR)/usr",--without-ssl)
 $(PKG)_CONFIGURE_OPTIONS += $(if $(FREETZ_LIB_libcurl_WITH_MBEDTLS),--with-mbedtls="$(TARGET_TOOLCHAIN_STAGING_DIR)/usr",--without-mbedtls)
-$(PKG)_CONFIGURE_OPTIONS += --without-ca-bundle
+$(PKG)_CONFIGURE_OPTIONS += $(if $(FREETZ_PACKAGE_CACERTS),--with-ca-bundle=$(FREETZ_CACERTS_DIR)"/cacert.pem",--without-ca-bundle)
 $(PKG)_CONFIGURE_OPTIONS += --without-gssapi
 $(PKG)_CONFIGURE_OPTIONS += --without-libidn
 $(PKG)_CONFIGURE_OPTIONS += --without-libmetalink


### PR DESCRIPTION
when using curl and other packages which rely on TLS client auth, ca-bundle is required.
This package simply downloads latests cacerts.pem and place it in /etc/ssl/certs/cacert.pem.

if CACERT package was selected, curl will be configured with option "--with-ca-bundle"