### PR TITLE
Cacerts

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -197,7 +197,7 @@ Latest changes:
     * tinc 1.0.35/1.1pre17
     * tinyproxy 1.8.4
     * tmux 2.5
-    * tor 0.3.5.8
+    * tor 0.4.0.5
     * transmission 2.94
     * tree 1.8.0
     * uClibc++ 0.2.5-git

--- a/make/cacerts/Config.in
+++ b/make/cacerts/Config.in
@@ -3,10 +3,4 @@ config FREETZ_PACKAGE_CACERTS
 	default n
 	help
 		This package provides up-to-date ca-certs from curl.haxx.se
-
-config FREETZ_PACKAGE_CACERTS_FORCE_DOWNLOAD
-	bool "Force update on each build"
-	depends on FREETZ_PACKAGE_CACERTS
-	default y
-	help
-		Download the latest ca-bundle each time freetz is built.
+	

--- a/make/cacerts/Config.in
+++ b/make/cacerts/Config.in
@@ -9,11 +9,4 @@ config FREETZ_PACKAGE_CACERTS_FORCE_DOWNLOAD
 	depends on FREETZ_PACKAGE_CACERTS
 	default y
 	help
-		Download the latest cacerts each time freetz is built.
-
-config FREETZ_CACERTS_DIR
-	string "Folder to place cacert.pem"
-	depends on FREETZ_PACKAGE_CACERTS
-	default "/etc/ssl/certs"
-	help
-		The location of cacerts.pem file.
+		Download the latest ca-bundle each time freetz is built.

--- a/make/cacerts/Config.in
+++ b/make/cacerts/Config.in
@@ -1,0 +1,19 @@
+config FREETZ_PACKAGE_CACERTS
+	bool "CA Certs"
+	default n
+	help
+		This package provides up-to-date ca-certs from curl.haxx.se
+
+config FREETZ_PACKAGE_CACERTS_FORCE_DOWNLOAD
+	bool "Force update on each build"
+	depends on FREETZ_PACKAGE_CACERTS
+	default y
+	help
+		Download the latest cacerts each time freetz is built.
+
+config FREETZ_CACERTS_DIR
+	string "Folder to place cacert.pem"
+	depends on FREETZ_PACKAGE_CACERTS
+	default "/etc/ssl/certs"
+	help
+		The location of cacerts.pem file.

--- a/make/cacerts/cacerts.mk
+++ b/make/cacerts/cacerts.mk
@@ -1,0 +1,23 @@
+$(call PKG_INIT_BIN, 0.1)
+$(PKG)_SOURCE:=cacert.pem
+$(PKG)_SITE:=https://curl.haxx.se/ca
+
+$(PKG)_TARGET_PATH:=/etc/ssl/certs/
+
+$(if $(FREETZ_PACKAGE_CACERTS_FORCE_DOWNLOAD),.PHONY: $(DL_DIR)/$($(PKG)_SOURCE))
+
+$(PKG_SOURCE_DOWNLOAD)
+
+$($(PKG)_DEST_DIR)$($(PKG)_TARGET_PATH): $(DL_DIR)/$($(PKG)_SOURCE)
+	$(INSTALL_FILE)
+
+$(pkg):
+
+$(pkg)-precompiled: $($(PKG)_DEST_DIR)$($(PKG)_TARGET_PATH)
+
+$(pkg)-clean:
+
+$(pkg)-uninstall:
+	$(RM) $($(PKG)_DEST_DIR)$($(PKG)_TARGET_PATH)
+
+$(PKG_FINISH)

--- a/make/cacerts/cacerts.mk
+++ b/make/cacerts/cacerts.mk
@@ -1,19 +1,19 @@
-$(call PKG_INIT_BIN, 0.1)
-$(PKG)_SOURCE:=cacert.pem
+$(call PKG_INIT_BIN, 2019-05-15)
+$(PKG)_SOURCE:=cacert-$($(PKG)_VERSION).pem
+$(PKG)_SOURCE_SHA256:=cb2eca3fbfa232c9e3874e3852d43b33589f27face98eef10242a853d83a437a
 $(PKG)_SITE:=https://curl.haxx.se/ca
 
-$(PKG)_TARGET_PATH:=/etc/ssl/certs/
-
-$(if $(FREETZ_PACKAGE_CACERTS_FORCE_DOWNLOAD),.PHONY: $(DL_DIR)/$($(PKG)_SOURCE))
+$(PKG)_BINARY:=$(DL_DIR)/$($(PKG)_SOURCE)
+$(PKG)_TARGET_BINARY:=$($(PKG)_DEST_DIR)/etc/ssl/certs/cacert.pem
 
 $(PKG_SOURCE_DOWNLOAD)
 
-$($(PKG)_DEST_DIR)$($(PKG)_TARGET_PATH): $(DL_DIR)/$($(PKG)_SOURCE)
+$($(PKG)_TARGET_BINARY): $($(PKG)_BINARY)
 	$(INSTALL_FILE)
 
 $(pkg):
 
-$(pkg)-precompiled: $($(PKG)_DEST_DIR)$($(PKG)_TARGET_PATH)
+$(pkg)-precompiled: $($(PKG)_TARGET_BINARY)
 
 $(pkg)-clean:
 

--- a/make/curl/curl.mk
+++ b/make/curl/curl.mk
@@ -78,7 +78,7 @@ $(PKG)_CONFIGURE_OPTIONS += --without-gnutls
 $(PKG)_CONFIGURE_OPTIONS += --without-polarssl
 $(PKG)_CONFIGURE_OPTIONS += $(if $(FREETZ_LIB_libcurl_WITH_OPENSSL),--with-ssl="$(TARGET_TOOLCHAIN_STAGING_DIR)/usr",--without-ssl)
 $(PKG)_CONFIGURE_OPTIONS += $(if $(FREETZ_LIB_libcurl_WITH_MBEDTLS),--with-mbedtls="$(TARGET_TOOLCHAIN_STAGING_DIR)/usr",--without-mbedtls)
-$(PKG)_CONFIGURE_OPTIONS += $(if $(FREETZ_PACKAGE_CACERTS),--with-ca-bundle=/etc/ssl/certs/cacert.pem",--without-ca-bundle)
+$(PKG)_CONFIGURE_OPTIONS += $(if $(FREETZ_PACKAGE_CACERTS),--with-ca-bundle="/etc/ssl/certs/cacert.pem",--without-ca-bundle)
 $(PKG)_CONFIGURE_OPTIONS += --without-gssapi
 $(PKG)_CONFIGURE_OPTIONS += --without-libidn
 $(PKG)_CONFIGURE_OPTIONS += --without-libmetalink

--- a/make/curl/curl.mk
+++ b/make/curl/curl.mk
@@ -78,7 +78,7 @@ $(PKG)_CONFIGURE_OPTIONS += --without-gnutls
 $(PKG)_CONFIGURE_OPTIONS += --without-polarssl
 $(PKG)_CONFIGURE_OPTIONS += $(if $(FREETZ_LIB_libcurl_WITH_OPENSSL),--with-ssl="$(TARGET_TOOLCHAIN_STAGING_DIR)/usr",--without-ssl)
 $(PKG)_CONFIGURE_OPTIONS += $(if $(FREETZ_LIB_libcurl_WITH_MBEDTLS),--with-mbedtls="$(TARGET_TOOLCHAIN_STAGING_DIR)/usr",--without-mbedtls)
-$(PKG)_CONFIGURE_OPTIONS += --without-ca-bundle
+$(PKG)_CONFIGURE_OPTIONS += $(if $(FREETZ_PACKAGE_CACERTS),--with-ca-bundle=$(FREETZ_CACERTS_DIR)"/cacert.pem",--without-ca-bundle)
 $(PKG)_CONFIGURE_OPTIONS += --without-gssapi
 $(PKG)_CONFIGURE_OPTIONS += --without-libidn
 $(PKG)_CONFIGURE_OPTIONS += --without-libmetalink

--- a/make/curl/curl.mk
+++ b/make/curl/curl.mk
@@ -78,7 +78,7 @@ $(PKG)_CONFIGURE_OPTIONS += --without-gnutls
 $(PKG)_CONFIGURE_OPTIONS += --without-polarssl
 $(PKG)_CONFIGURE_OPTIONS += $(if $(FREETZ_LIB_libcurl_WITH_OPENSSL),--with-ssl="$(TARGET_TOOLCHAIN_STAGING_DIR)/usr",--without-ssl)
 $(PKG)_CONFIGURE_OPTIONS += $(if $(FREETZ_LIB_libcurl_WITH_MBEDTLS),--with-mbedtls="$(TARGET_TOOLCHAIN_STAGING_DIR)/usr",--without-mbedtls)
-$(PKG)_CONFIGURE_OPTIONS += $(if $(FREETZ_PACKAGE_CACERTS),--with-ca-bundle=$(FREETZ_CACERTS_DIR)"/cacert.pem",--without-ca-bundle)
+$(PKG)_CONFIGURE_OPTIONS += $(if $(FREETZ_PACKAGE_CACERTS),--with-ca-bundle=/etc/ssl/certs/cacert.pem",--without-ca-bundle)
 $(PKG)_CONFIGURE_OPTIONS += --without-gssapi
 $(PKG)_CONFIGURE_OPTIONS += --without-libidn
 $(PKG)_CONFIGURE_OPTIONS += --without-libmetalink

--- a/make/tor/Config.in
+++ b/make/tor/Config.in
@@ -1,5 +1,5 @@
 config FREETZ_PACKAGE_TOR
-	bool "Tor 0.3.5.8"
+	bool "Tor 0.4.0.5"
 	select FREETZ_LIB_libm if ! FREETZ_PACKAGE_TOR_STATIC
 	select FREETZ_LIB_libevent if ! FREETZ_PACKAGE_TOR_STATIC
 	select FREETZ_LIB_libcrypto if ! FREETZ_PACKAGE_TOR_STATIC

--- a/make/tor/tor.mk
+++ b/make/tor/tor.mk
@@ -1,6 +1,6 @@
-$(call PKG_INIT_BIN, 0.3.5.8)
+$(call PKG_INIT_BIN, 0.4.0.5)
 $(PKG)_SOURCE:=$(pkg)-$($(PKG)_VERSION).tar.gz
-$(PKG)_SOURCE_SHA256:=d5c56603942a8927670f50a4a469fb909e29d3571fdd013389d567e57abc0b47
+$(PKG)_SOURCE_SHA256:=b5a2cbf0dcd3f1df2675dbd5ec10bbe6f8ae995c41b68cebe2bc95bffc90696e
 $(PKG)_SITE:=https://www.torproject.org/dist
 
 $(PKG)_BINARY:=$($(PKG)_DIR)/src/app/tor

--- a/tools/freetz_download
+++ b/tools/freetz_download
@@ -51,8 +51,8 @@ do_download()
 
 	echo
 	[ "$DEBUG" == "1" ] && echo \
-	"wget -nd -t3 --timeout=20 --no-check-certificate --passive-ftp -N -P \"${1%/}/\" \"${fullURL}\""
-	 wget -nd -t3 --timeout=20 --no-check-certificate --passive-ftp -N -P  "${1%/}/"   "${fullURL}"
+	"wget -nd -t3 --timeout=20 --passive-ftp -N -P \"${1%/}/\" \"${fullURL}\""
+	 wget -nd -t3 --timeout=20 --passive-ftp -N -P  "${1%/}/"   "${fullURL}"
 	wget_result=$?
 	if [ "$wget_result" != "0" ]; then
 		echo "Download failed - \"${fullURL}\"  ->  error code $wget_result" >&2
@@ -67,8 +67,8 @@ do_check()
 	local mode wget_output wget_result
 	for mode in --spider --output-document=/dev/null; do
 		[ "$DEBUG" == "1" ] && \
-		echo         "LC_ALL=C wget -t3 --timeout=20 --no-check-certificate --passive-ftp -S $mode \"$1\" 2>&1"
-		wget_output=$(LC_ALL=C wget -t3 --timeout=20 --no-check-certificate --passive-ftp -S $mode "$1" 2>&1)
+		echo         "LC_ALL=C wget -t3 --timeout=20 --passive-ftp -S $mode \"$1\" 2>&1"
+		wget_output=$(LC_ALL=C wget -t3 --timeout=20 --passive-ftp -S $mode "$1" 2>&1)
 		wget_result=$?
 		if [ "$wget_result" != "0" ]; then
 			# workaround wget spider-mode bug (false negative): known to happen with all sites
@@ -120,7 +120,7 @@ do_checkout_svn()
 }
 do_checkout_git()
 {
-	GIT_SSL_NO_VERIFY=true git clone "$1" "$2" \
+	git clone "$1" "$2" \
 	&& pushd "$2" >/dev/null \
 	&& git checkout "$3" \
 	&& LAST_COMMIT_TIMESTAMP=$(git log -1 --pretty=format:%cD) \


### PR DESCRIPTION
CACERTS will download ca-bundle file and place in /etc/ssl/certs/cacert.pem.
CA-Bundle is required for applications using TLS server auth like curl, stubby (getdns), ...
Further if CACERTS is selected in menuconfig, curl will be configured with "--with-ca-bundle" and set to apropriate location.
This is first version of package intended to bring updated ca-bundle into freetz image. 
I will be happy with any feedback especially about filesystem location.
In future box should update ca-bundle periodically itself, but an initial ca-bundle will always be required to start.