### PR TITLE
added package cacerts. It will download ca-bundel from curl.haxx.se a…

### DIFF
--- a/make/cacerts/Config.in
+++ b/make/cacerts/Config.in
@@ -1,0 +1,6 @@
+config FREETZ_PACKAGE_CACERTS
+	bool "CA Certs"
+	default n
+	help
+		This package provides up-to-date ca-certs from curl.haxx.se
+	

--- a/make/cacerts/cacerts.mk
+++ b/make/cacerts/cacerts.mk
@@ -7,6 +7,7 @@ $(PKG)_BINARY:=$(DL_DIR)/$($(PKG)_SOURCE)
 $(PKG)_TARGET_BINARY:=$($(PKG)_DEST_DIR)/etc/ssl/certs/cacert.pem
 
 $(PKG_SOURCE_DOWNLOAD)
+$(PKG_UNPACKED)
 
 $($(PKG)_TARGET_BINARY): $($(PKG)_BINARY)
 	$(INSTALL_FILE)
@@ -18,6 +19,6 @@ $(pkg)-precompiled: $($(PKG)_TARGET_BINARY)
 $(pkg)-clean:
 
 $(pkg)-uninstall:
-	$(RM) $($(PKG)_DEST_DIR)$($(PKG)_TARGET_PATH)
+	$(RM) $(CACERTS_TARGET_BINARY)
 
 $(PKG_FINISH)

--- a/make/cacerts/cacerts.mk
+++ b/make/cacerts/cacerts.mk
@@ -1,0 +1,23 @@
+$(call PKG_INIT_BIN, 2019-05-15)
+$(PKG)_SOURCE:=cacert-$($(PKG)_VERSION).pem
+$(PKG)_SOURCE_SHA256:=cb2eca3fbfa232c9e3874e3852d43b33589f27face98eef10242a853d83a437a
+$(PKG)_SITE:=https://curl.haxx.se/ca
+
+$(PKG)_BINARY:=$(DL_DIR)/$($(PKG)_SOURCE)
+$(PKG)_TARGET_BINARY:=$($(PKG)_DEST_DIR)/etc/ssl/certs/cacert.pem
+
+$(PKG_SOURCE_DOWNLOAD)
+
+$($(PKG)_TARGET_BINARY): $($(PKG)_BINARY)
+	$(INSTALL_FILE)
+
+$(pkg):
+
+$(pkg)-precompiled: $($(PKG)_TARGET_BINARY)
+
+$(pkg)-clean:
+
+$(pkg)-uninstall:
+	$(RM) $($(PKG)_DEST_DIR)$($(PKG)_TARGET_PATH)
+
+$(PKG_FINISH)

--- a/make/cacerts/files/root/etc/profile.d/cacerts.sh
+++ b/make/cacerts/files/root/etc/profile.d/cacerts.sh
@@ -1,0 +1,2 @@
+# setting CA-Bundle file location via SSL_CERT_FILE - used by OpenSSL-lib
+export SSL_CERT_FILE=/etc/ssl/certs/cacert.pem

--- a/make/curl/curl.mk
+++ b/make/curl/curl.mk
@@ -78,7 +78,7 @@ $(PKG)_CONFIGURE_OPTIONS += --without-gnutls
 $(PKG)_CONFIGURE_OPTIONS += --without-polarssl
 $(PKG)_CONFIGURE_OPTIONS += $(if $(FREETZ_LIB_libcurl_WITH_OPENSSL),--with-ssl="$(TARGET_TOOLCHAIN_STAGING_DIR)/usr",--without-ssl)
 $(PKG)_CONFIGURE_OPTIONS += $(if $(FREETZ_LIB_libcurl_WITH_MBEDTLS),--with-mbedtls="$(TARGET_TOOLCHAIN_STAGING_DIR)/usr",--without-mbedtls)
-$(PKG)_CONFIGURE_OPTIONS += $(if $(FREETZ_PACKAGE_CACERTS),--with-ca-bundle="/etc/ssl/certs/cacert.pem",--without-ca-bundle)
+$(PKG)_CONFIGURE_OPTIONS += --without-ca-bundle
 $(PKG)_CONFIGURE_OPTIONS += --without-gssapi
 $(PKG)_CONFIGURE_OPTIONS += --without-libidn
 $(PKG)_CONFIGURE_OPTIONS += --without-libmetalink

--- a/make/curl/curl.mk
+++ b/make/curl/curl.mk
@@ -78,7 +78,7 @@ $(PKG)_CONFIGURE_OPTIONS += --without-gnutls
 $(PKG)_CONFIGURE_OPTIONS += --without-polarssl
 $(PKG)_CONFIGURE_OPTIONS += $(if $(FREETZ_LIB_libcurl_WITH_OPENSSL),--with-ssl="$(TARGET_TOOLCHAIN_STAGING_DIR)/usr",--without-ssl)
 $(PKG)_CONFIGURE_OPTIONS += $(if $(FREETZ_LIB_libcurl_WITH_MBEDTLS),--with-mbedtls="$(TARGET_TOOLCHAIN_STAGING_DIR)/usr",--without-mbedtls)
-$(PKG)_CONFIGURE_OPTIONS += --without-ca-bundle
+$(PKG)_CONFIGURE_OPTIONS += $(if $(FREETZ_PACKAGE_CACERTS),--with-ca-bundle="/etc/ssl/certs/cacert.pem",--without-ca-bundle)
 $(PKG)_CONFIGURE_OPTIONS += --without-gssapi
 $(PKG)_CONFIGURE_OPTIONS += --without-libidn
 $(PKG)_CONFIGURE_OPTIONS += --without-libmetalink


### PR DESCRIPTION
…nd place in /etc/ssl/certs/cacert.pem.

further it's recommended to add location in .profile:
export SSL_CERT_FILE=/etc/ssl/certs/cacert.pem