### PR TITLE
php: bump version to 5.6.40

### DIFF
--- a/make/php/Config.in
+++ b/make/php/Config.in
@@ -17,7 +17,7 @@ choice
 	default FREETZ_PHP_VERSION_5_6
 
 	config FREETZ_PHP_VERSION_5_6
-		bool "php 5.6.37"
+		bool "php 5.6.40"
 endchoice
 
 menu "Binaries"


### PR DESCRIPTION
Heyo, wie besprochen zunächst der bump.
5.6.37 funktionierte mit PKG_PREVENT_RPATH_HARDCODING - 5.6.40 zeigte damit leider fehlende Libs beim starten. Die einfachste Lösung schien mir, selbst sicher zu stellen, das die libtool variablen gesetzt werden. Wenns hier eine sinnvollere Lösung gibt teste ich die natürlich gerne.  
viele Grüße,
Thorsten