### PR TITLE
draft: support php with shared libs

### DIFF
--- a/make/php/patches/5.6/680-support-sharedLibs.patch
+++ b/make/php/patches/5.6/680-support-sharedLibs.patch
@@ -1,0 +1,26 @@
+// Fix using shared libs with php (phpinfo->General->Dynamic Library support)
+--- configure.in
++++ configure.in
+@@ -453,8 +453,9 @@
+ PHP_CHECK_FUNC(gethostbyaddr, nsl)
+ PHP_CHECK_FUNC(yp_get_default_domain, nsl)
+ 
+-PHP_CHECK_FUNC(dlopen, dl)
+ if test "$ac_cv_func_dlopen" = "yes"; then
++  PHP_ADD_LIBRARY(dl)
++  PHP_DEF_HAVE(dlopen)
+   AC_DEFINE(HAVE_LIBDL, 1, [ ])
+ fi
+ AC_CHECK_LIB(m, sin)
+--- configure
++++ configure
+@@ -17682,7 +17682,7 @@
+     ac_libs=$LIBS
+     LIBS="$LIBS -ldl"
+     if test "$cross_compiling" = yes; then :
+-  found=no
++#  found=no
+ else
+   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+

--- a/make/php/php.mk
+++ b/make/php/php.mk
@@ -28,6 +28,9 @@ $(PKG)_CONFIGURE_OPTIONS += --with-pcre-regex="$(TARGET_TOOLCHAIN_STAGING_DIR)/u
 
 $(PKG)_CONFIGURE_OPTIONS += --enable-cli
 $(PKG)_EXCLUDED += $(if $(FREETZ_PACKAGE_PHP_cli),,$($(PKG)_CLI_TARGET_BINARY))
+$(PKG)_CONFIGURE_OPTIONS += --enable-shared
+$(PKG)_CONFIGURE_ENV +=ac_cv_func_dlopen=yes ac_cv_lib_dl_dlopen=yes ac_cv_func_mprotect=yes
+# ^ fix configure to enable dynamic library loading when cross-compiling.
 
 ifeq ($(strip $(FREETZ_PACKAGE_PHP_apxs2)),y)
 $(PKG)_DEPENDS_ON += apache2


### PR DESCRIPTION
Heio..
Hier nun der erste hunk aus dem OpenWrt [patch ](https://bugs.php.net/patch-display.php?bug_id=69132&patch=950-Fix-dl-cross-compiling-issue.patch&revision=latest) zu [issue 219](https://github.com/Freetz/freetz/issues/219)
Damit erhält php die funktionalität, libraries nach zu laden.
siehe phpinfo->standard->Dynamic Library support
viele Grüße,
Thorsten
