### PR TITLE
haproxy version bump -> haproxy 1.8.22

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -117,7 +117,7 @@ Latest changes:
     * gmp 6.1.2
     * gnu-make 4.2.1
     * gnutls 3.5.19
-    * haproxy 1.8.21
+    * haproxy 1.8.22
     * haserl 0.9.35
     * hplip 3.14.6
     * htop 1.0.3

--- a/make/haproxy/Config.in
+++ b/make/haproxy/Config.in
@@ -1,5 +1,5 @@
 config FREETZ_PACKAGE_HAPROXY
-	bool "HAProxy 1.8.21"
+	bool "HAProxy 1.8.22"
 	select FREETZ_LIB_libcrypt
 	select FREETZ_BUSYBOX_START_STOP_DAEMON
 	default n

--- a/make/haproxy/haproxy.mk
+++ b/make/haproxy/haproxy.mk
@@ -1,6 +1,6 @@
-$(call PKG_INIT_BIN, 1.8.21)
+$(call PKG_INIT_BIN, 1.8.22)
 $(PKG)_SOURCE:=$(pkg)-$($(PKG)_VERSION).tar.gz
-$(PKG)_SOURCE_256:=34bc80bbaab6edae80add1e8b321636e50ccc56cb583040d98d5d245570680e1
+$(PKG)_SOURCE_256:=7be245cdbc3fff9365af1df1c13fdff768fb7f9c4363e7daa52c315ec20dc1f8
 $(PKG)_SITE:=http://www.haproxy.org/download/1.8/src
 
 $(PKG)_BINARY:=$($(PKG)_DIR)/haproxy


### PR DESCRIPTION
changelog: http://git.haproxy.org/?p=haproxy-1.8.git;a=log;h=refs/tags/v1.8.22