### PR TITLE
Add a config option to remove urladerupgrade from GRX5 firmware image

### DIFF
--- a/config/ui/patches.in
+++ b/config/ui/patches.in
@@ -1527,6 +1527,19 @@ config FREETZ_RUN_TELEFON_IN_INHOUSE_MODE
 		- processing of /var/flash/fx_conf attributes responsible
 		  for automatic start of the telnet daemon
 
+config FREETZ_FORCE_SKIP_URLADERUPDATE
+	bool "Enforce skipping of urlader update contained in original image"
+	depends on FREETZ_SHOW_EXPERT
+	depends on FREETZ_SYSTEM_TYPE_GRX5
+	default n
+	help
+		Removes file "urladerupdate" in firmware package.
+		New bootloaders often lock down hardware even more. Therefore it might
+		be desirable to stay on the bootloader, that was delivered with the box.
+		Be aware, that the new firmware might depend on features in the updated
+		bootloader and not behave as expected if staying on the old one!
+		This option is experimental!
+
 comment "AVM daemons ----------------------------"
 
 config FREETZ_AVMDAEMON_DISABLE_IGD

--- a/patches/scripts/090-var_install_fixes.sh
+++ b/patches/scripts/090-var_install_fixes.sh
@@ -22,3 +22,10 @@ modsed '/mount -t ext2 \/var\/tmp\/fsimage.ext2/ a\
 echo '"'"'    fi'"'"' >> /var/post_install' "${var_install_file}"
 
 fi
+
+if [ "$FREETZ_FORCE_SKIP_URLADERUPDATE" == "y" ]; then
+	if [ -f "${FIRMWARE_MOD_DIR}/var/urladerupdate" ]; then
+		rm "${FIRMWARE_MOD_DIR}/var/urladerupdate"
+		echo1 "removing urladerupdate from firmware .image"
+	fi
+fi


### PR DESCRIPTION
Idea: New bootloaders often lock down hardware even more. A good example was the ability to set the branding environment variable in older versions of the bootloader, which at some point got locked down by AVM. Often it is not even needed to have an up-to-date bootloader. Therefore, I think it's a good idea, to have an option for that.

The change only supports GRX5 boxes for now. I don't know how bootloader updates are handled on other boxes.

Also, I marked it as experimental, as there might also be negative side effects, when the bootloader is not up-to-date with the actual system.

Tested on 7590.