### PR TITLE
Tor version bump -> 0.4.2.5

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -198,7 +198,7 @@ Latest changes:
     * tinc 1.0.35/1.1pre17
     * tinyproxy 1.8.4
     * tmux 2.5
-    * tor 0.4.1.6
+    * tor 0.4.2.5
     * transmission 2.94
     * tree 1.8.0
     * uClibc++ 0.2.5-git

--- a/make/tor/Config.in
+++ b/make/tor/Config.in
@@ -1,5 +1,5 @@
 config FREETZ_PACKAGE_TOR
-	bool "Tor 0.4.1.6"
+	bool "Tor 0.4.2.5"
 	select FREETZ_LIB_libm if ! FREETZ_PACKAGE_TOR_STATIC
 	select FREETZ_LIB_libevent if ! FREETZ_PACKAGE_TOR_STATIC
 	select FREETZ_LIB_libcrypto if ! FREETZ_PACKAGE_TOR_STATIC

--- a/make/tor/tor.mk
+++ b/make/tor/tor.mk
@@ -1,6 +1,6 @@
-$(call PKG_INIT_BIN, 0.4.1.6)
+$(call PKG_INIT_BIN, 0.4.2.5)
 $(PKG)_SOURCE:=$(pkg)-$($(PKG)_VERSION).tar.gz
-$(PKG)_SOURCE_SHA256:=2a88524ce426079fb9b828bc1b789f2c8ade3ed53c130851102debc3518bed71
+$(PKG)_SOURCE_SHA256:=4d5975862e7808faebe9960def6235669fafeeac844cb76965501fa7af79d8c2
 $(PKG)_SITE:=https://www.torproject.org/dist
 
 $(PKG)_BINARY:=$($(PKG)_DIR)/src/app/tor


### PR DESCRIPTION
Changelog: 
https://gitweb.torproject.org/tor.git/tree/ChangeLog?h=tor-0.4.2.5&id=bede4ea1008920d8b1b9ea72b0f44cb2ea4dbc6b