### PR TITLE
haproxy version bump -> 1.8.24

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -118,7 +118,7 @@ Latest changes:
     * gmp 6.1.2
     * gnu-make 4.2.1
     * gnutls 3.5.19
-    * haproxy 1.8.23
+    * haproxy 1.8.24
     * haserl 0.9.35
     * hplip 3.14.6
     * htop 1.0.3

--- a/make/haproxy/Config.in
+++ b/make/haproxy/Config.in
@@ -1,5 +1,5 @@
 config FREETZ_PACKAGE_HAPROXY
-	bool "HAProxy 1.8.23"
+	bool "HAProxy 1.8.24"
 	select FREETZ_LIB_libcrypt
 	select FREETZ_BUSYBOX_START_STOP_DAEMON
 	default n

--- a/make/haproxy/haproxy.mk
+++ b/make/haproxy/haproxy.mk
@@ -1,6 +1,6 @@
-$(call PKG_INIT_BIN, 1.8.23)
+$(call PKG_INIT_BIN, 1.8.24)
 $(PKG)_SOURCE:=$(pkg)-$($(PKG)_VERSION).tar.gz
-$(PKG)_SOURCE_SHA256:=de919164876ee0501e1ef01ca5ccc0d3bda2b96003f9d240f7b856010ccbf7eb
+$(PKG)_SOURCE_SHA256:=da4bc3db58105f2016a706b5c0242a6c870266c69581146ac7c363210604771a
 $(PKG)_SITE:=http://www.haproxy.org/download/1.8/src
 
 $(PKG)_BINARY:=$($(PKG)_DIR)/haproxy


### PR DESCRIPTION
Changelog: http://www.haproxy.org/download/1.8/src/CHANGELOG