### PR TITLE
haproxy: bump version to 1.8.25

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -119,7 +119,7 @@ Latest changes:
     * gmp 6.1.2
     * gnu-make 4.2.1
     * gnutls 3.5.19
-    * haproxy 1.8.24
+    * haproxy 1.8.25
     * haserl 0.9.35
     * hplip 3.14.6
     * htop 1.0.3

--- a/make/haproxy/Config.in
+++ b/make/haproxy/Config.in
@@ -1,5 +1,5 @@
 config FREETZ_PACKAGE_HAPROXY
-	bool "HAProxy 1.8.24"
+	bool "HAProxy 1.8.25"
 	select FREETZ_LIB_libcrypt
 	select FREETZ_BUSYBOX_START_STOP_DAEMON
 	default n

--- a/make/haproxy/haproxy.mk
+++ b/make/haproxy/haproxy.mk
@@ -1,6 +1,6 @@
-$(call PKG_INIT_BIN, 1.8.24)
+$(call PKG_INIT_BIN, 1.8.25)
 $(PKG)_SOURCE:=$(pkg)-$($(PKG)_VERSION).tar.gz
-$(PKG)_SOURCE_SHA256:=da4bc3db58105f2016a706b5c0242a6c870266c69581146ac7c363210604771a
+$(PKG)_SOURCE_SHA256:=62c0b77de2275a54a443a869947ddcca2bad7bdc1cafd804732a0e0d59b1708b
 $(PKG)_SITE:=http://www.haproxy.org/download/1.8/src
 
 $(PKG)_BINARY:=$($(PKG)_DIR)/haproxy

--- a/make/haproxy/patches/010-disable_epoll_for_kernel_smaller_2.6.28.patch
+++ b/make/haproxy/patches/010-disable_epoll_for_kernel_smaller_2.6.28.patch
@@ -1,6 +1,6 @@
 --- Makefile
 +++ Makefile
-@@ -288,10 +288,9 @@
+@@ -287,10 +287,9 @@
    USE_DL          = implicit
  else
  ifeq ($(TARGET),linux26)


### PR DESCRIPTION
Changelog: http://www.haproxy.org/download/1.8/src/CHANGELOG