### PR TITLE
Makefile: remove key password from .config.compressed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -385,8 +385,9 @@ config: config-cache $(CONFIG)/conf
 config-compress: .config.compressed
 .config.compressed: .config config-cache $(CONFIG)/conf
 	@$(CONFIG)/conf --savedefconfig $@ $(CONFIG_IN_CACHE)
+	@sed -e "/^FREETZ_FWMOD_SIGN_PRIVATE_KEY_PASSWORD=/d" -i $@ 2>/dev/null
 	@echo "Compressed configuration written to $@."; \
-	echo  "It is equivalent to .config, but contains only non-default user selections."
+	echo  "It is equivalent to .config, but contains only non-default user selections and no signing key password."
 
 oldconfig oldnoconfig allnoconfig allyesconfig randconfig listnewconfig: config-cache $(CONFIG)/conf
 	@$(CONFIG)/conf --$@ $(CONFIG_IN_CACHE)


### PR DESCRIPTION
Quick fix (first idea) to avoid password compromise while adding `.config.compressed` to any error reports. It does not cover the *original* `.config` file, if a user adds this one to his report.

A much better solution would (imho) be a "collect-diagnose-data" script, which uses the existing `fmake` script to produce a detailed log file of the error case and puts this log, together with the compressed and cleaned-up configuration file, into one single ZIP file, which may be uploaded/added by the reporting user.