### PR TITLE
Fix kernel 2.6.39 host tools compilation with gcc 10

### DIFF
--- a/make/linux/patches/2.6.39.3.x86/220-fix_gcc10_dtc.patch
+++ b/make/linux/patches/2.6.39.3.x86/220-fix_gcc10_dtc.patch
@@ -1,0 +1,11 @@
+--- linux-2.6.39/scripts/dtc/dtc-parser.tab.c_shipped
++++ linux-2.6.39/scripts/dtc/dtc-parser.tab.c_shipped
+@@ -75,7 +75,7 @@
+ #include "dtc.h"
+ #include "srcpos.h"
+ 
+-YYLTYPE yylloc;
++extern YYLTYPE yylloc;
+ 
+ extern int yylex(void);
+ extern void print_error(char const *fmt, ...);


### PR DESCRIPTION
related to
https://git.kernel.org/pub/scm/utils/dtc/dtc.git/patch/?id=0e9225eb0dfec51def612b928d2f1836b092bc7e