### PR TITLE
tor: bump version to 0.4.3.5

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -199,7 +199,7 @@ Latest changes:
     * tinc 1.0.35/1.1pre17
     * tinyproxy 1.8.4
     * tmux 2.5
-    * tor 0.4.2.7
+    * tor 0.4.3.5
     * transmission 2.94
     * tree 1.8.0
     * uClibc++ 0.2.5-git

--- a/make/tor/Config.in
+++ b/make/tor/Config.in
@@ -1,5 +1,5 @@
 config FREETZ_PACKAGE_TOR
-	bool "Tor 0.4.2.7"
+	bool "Tor 0.4.3.5"
 	select FREETZ_LIB_libm if ! FREETZ_PACKAGE_TOR_STATIC
 	select FREETZ_LIB_libevent if ! FREETZ_PACKAGE_TOR_STATIC
 	select FREETZ_LIB_libcrypto if ! FREETZ_PACKAGE_TOR_STATIC

--- a/make/tor/patches/010-drop_backtrace_support.patch
+++ b/make/tor/patches/010-drop_backtrace_support.patch
@@ -1,6 +1,6 @@
 --- configure.ac
 +++ configure.ac
-@@ -581,8 +581,6 @@
+@@ -659,8 +659,6 @@
  	RtlSecureZeroMemory \
  	SecureZeroMemory \
  	accept4 \
@@ -11,7 +11,7 @@
  	timingsafe_memcmp \
 --- configure
 +++ configure
-@@ -8607,8 +8607,6 @@
+@@ -8767,8 +8767,6 @@
  	RtlSecureZeroMemory \
  	SecureZeroMemory \
  	accept4 \
@@ -20,7 +20,7 @@
  	eventfd \
  	explicit_bzero \
  	timingsafe_memcmp \
-@@ -12646,7 +12644,6 @@
+@@ -12840,7 +12838,6 @@
  		  unistd.h \
  		  arpa/inet.h \
  		  crt_externs.h \

--- a/make/tor/tor.mk
+++ b/make/tor/tor.mk
@@ -1,6 +1,6 @@
-$(call PKG_INIT_BIN, 0.4.2.7)
+$(call PKG_INIT_BIN, 0.4.3.5)
 $(PKG)_SOURCE:=$(pkg)-$($(PKG)_VERSION).tar.gz
-$(PKG)_SOURCE_SHA256:=06a1d835ddf382f6bca40a62e8fb40b71b2f73d56f0d53523c8bd5caf9b3026d
+$(PKG)_SOURCE_SHA256:=616a0e4ae688d0e151d46e3e4258565da4d443d1ddbd316db0b90910e2d5d868
 $(PKG)_SITE:=https://www.torproject.org/dist
 
 $(PKG)_BINARY:=$($(PKG)_DIR)/src/app/tor


### PR DESCRIPTION
CHANGELOG: 
https://gitweb.torproject.org/tor.git/plain/ChangeLog?h=tor-0.4.3.5