### PR TITLE
.build-prerequisites: 'bc' is needed for newer kernel sources, too

### DIFF
--- a/.build-prerequisites
+++ b/.build-prerequisites
@@ -24,6 +24,7 @@
 		-w	bison
 		-w	composite
 		-w	flex
+		-w	bc
 --header		ncurses.h
 			zlib.h
 			sys/acl.h


### PR DESCRIPTION
The file 'kernel/timeconst.h' is generated from a 'bc' program, see
'kernel/timeconst.bc' for details.