### PR TITLE
tools/make: contains source code

### DIFF
--- a/tools/.gitignore
+++ b/tools/.gitignore
@@ -43,3 +43,8 @@ xz
 xzcat
 yf
 zcat
+
+!/make
+!/make/
+!/make/*
+


### PR DESCRIPTION
 and should therefore be under Git control 

If there wasn't any good reason to exclude the whole `tools` directory from source control (I could not find any documentation belonging to), its sub-directory `make` should get included again, 'cause it contains "source" files as patches and even directly the source code for some tools (with "inline source").

Otherwise it should get documented clearly (a `.gitignore` file isn't enough, there should be a file with an explanation/description, e.g. a `README.md` in the `tools` sub-directory, too) - it's a waste of time for supporters, if they have to discover themselves, why source control doesn't work as expected below `tools` (new files are not detected, but changes to files already under source control are shown).

It's obviously, why the `tools` directory itself was excluded (this doesn't require an explanation for others in my opinion) - it contains compilation results after `make tools`. But this does not explain, why the `make` directory had not get included again as a whole (or better: the exclusion wasn't reverted again for this sub-directory).
