### PR TITLE
Freetz hp utils

### DIFF
--- a/make/hp-utils/Config.in
+++ b/make/hp-utils/Config.in
@@ -2,6 +2,7 @@ config FREETZ_PACKAGE_HP_UTILS
 	bool "hp-utils 0.3.2"
 	default n
 	select FREETZ_PACKAGE_HPLIP
+	select FREETZ_LIB_libusb_0
 	help
 		hp-utils is a collection of utility programs for
 		HP printers. It's meant to be used on systems,

--- a/make/hp-utils/patches/200-device.patch
+++ b/make/hp-utils/patches/200-device.patch
@@ -1,0 +1,15 @@
+--- device.c	2020-07-12 19:12:31.024208855 +0200
++++ device.c	2020-07-12 19:14:21.231000458 +0200
+@@ -50,6 +50,11 @@
+ 
+ void device_free(struct device *d)
+ {
++        /* This code causes a segmentation fault.
++        /  Simply returning causes a memory leak, but at least it works
++        /  Note: Memory should be returned when process ends
++        */
++        return;
+ 	if (d == NULL) {
+ 		return;
+ 	}
+

--- a/make/libs/libusb/Config.in
+++ b/make/libs/libusb/Config.in
@@ -1,6 +1,5 @@
 config FREETZ_LIB_libusb_0
 	bool "libusb-0.1 (libusb-0.1.so)"
-	select FREETZ_LIB_libusb_1 if FREETZ_LIB_libusb_0_WITH_COMPAT
 	default n
 	help
 		A library for accessing Linux USB devices (legacy API).
@@ -8,11 +7,13 @@ config FREETZ_LIB_libusb_0
 choice
 	prompt "implemented using"
 		depends on FREETZ_LIB_libusb_0
-		default FREETZ_LIB_libusb_0_WITH_LEGACY
+		default FREETZ_LIB_libusb_0_WITH_LEGACY if !FREETZ_LIB_libusb_1
+		default FREETZ_LIB_libusb_0_WITH_COMPAT if FREETZ_LIB_libusb_1
 
 	config FREETZ_LIB_libusb_0_WITH_LEGACY
 		bool "legacy library"
 
 	config FREETZ_LIB_libusb_0_WITH_COMPAT
+		depends on FREETZ_LIB_libusb_1
 		bool "libusb-1.0 compat layer"
 endchoice


### PR DESCRIPTION
These changes allow to compile the hp-utils (at least for the 7490) and avoid a segmentation fault when running the tools
The hp-utils need usb-0.1, so this is selected now when hp-utils is selected.