### PR TITLE
Freetz hplip

### DIFF
--- a/make/hplip/Config.in
+++ b/make/hplip/Config.in
@@ -3,6 +3,8 @@ config FREETZ_PACKAGE_HPLIP
 	select FREETZ_PACKAGE_SANE_BACKENDS
 	select FREETZ_LIB_libpthread
 	select FREETZ_LIB_libusb_1
+	select FREETZ_LIB_libusb_0
+	select FREETZ_LIB_libusb_0_WITH_COMPAT
 	default n
 	help
 		HPLIP - HP Linux Imaging and Printing

--- a/make/libs/libusb/Config.in
+++ b/make/libs/libusb/Config.in
@@ -1,6 +1,5 @@
 config FREETZ_LIB_libusb_0
 	bool "libusb-0.1 (libusb-0.1.so)"
-	select FREETZ_LIB_libusb_1 if FREETZ_LIB_libusb_0_WITH_COMPAT
 	default n
 	help
 		A library for accessing Linux USB devices (legacy API).
@@ -8,11 +7,13 @@ config FREETZ_LIB_libusb_0
 choice
 	prompt "implemented using"
 		depends on FREETZ_LIB_libusb_0
-		default FREETZ_LIB_libusb_0_WITH_LEGACY
+		default FREETZ_LIB_libusb_0_WITH_LEGACY if !FREETZ_LIB_libusb_1
+		default FREETZ_LIB_libusb_0_WITH_COMPAT if FREETZ_LIB_libusb_1
 
 	config FREETZ_LIB_libusb_0_WITH_LEGACY
 		bool "legacy library"
 
 	config FREETZ_LIB_libusb_0_WITH_COMPAT
+		depends on FREETZ_LIB_libusb_1
 		bool "libusb-1.0 compat layer"
 endchoice


### PR DESCRIPTION
These changes allow to compile the hplip (at least for the 7490)by setting usb-1 and libusb compatibility (e.g. also for hp-util)