### PR TITLE
Make sure that sane is compiled with dl support

### DIFF
--- a/make/sane-backends/patches/500-dlopen.patch
+++ b/make/sane-backends/patches/500-dlopen.patch
@@ -1,0 +1,17 @@
+--- configure	2020-07-12 21:46:14.502264360 +0200
++++ configure	2020-07-12 21:47:37.990006452 +0200
+@@ -16409,12 +16409,12 @@
+        for ac_func in dlopen
+ do :
+   ac_fn_c_check_func "$LINENO" "dlopen" "ac_cv_func_dlopen"
+-if test "x$ac_cv_func_dlopen" = xyes; then :
++#if test "x$ac_cv_func_dlopen" = xyes; then :
+   cat >>confdefs.h <<_ACEOF
+ #define HAVE_DLOPEN 1
+ _ACEOF
+  enable_dynamic=yes
+-fi
++#fi
+ done
+ 
+        LIBS="${saved_LIBS}"


### PR DESCRIPTION
In some configurations ./configure wrongly assumes that there is no
dlopen support. This results in an undefined HAVE_DLOPEN in
include/sane/config.h
As a result HPLIP support, which needs dll does not work correctly
This patch ensures that
 #define HAVE_DLOPEN 1
is set in the config.h

Note: I was unable to find a suitable ENV variable to ensure that dlopen is available. 
Note: This patch should also work if a system correctly has dlopen