### PR TITLE
In newer boxes the ftpuser is not in /etc/passwd

### DIFF
--- a/make/rsync/files/root/etc/default.rsync/rsync_conf
+++ b/make/rsync/files/root/etc/default.rsync/rsync_conf
@@ -4,7 +4,7 @@ echo "### global"
 
 cat << EOF
 max connections = $RSYNC_MAXCON
-uid = ftpuser
+uid = 1000 
 gid = root
 EOF
 


### PR DESCRIPTION
Using the numerical id 1000 ensures that rsync starts properly