### PR TITLE
tor: bump version to 0.4.3.6

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -199,7 +199,7 @@ Latest changes:
     * tinc 1.0.35/1.1pre17
     * tinyproxy 1.8.4
     * tmux 2.5
-    * tor 0.4.3.5
+    * tor 0.4.3.6
     * transmission 2.94
     * tree 1.8.0
     * uClibc++ 0.2.5-git

--- a/make/tor/Config.in
+++ b/make/tor/Config.in
@@ -1,5 +1,5 @@
 config FREETZ_PACKAGE_TOR
-	bool "Tor 0.4.3.5"
+	bool "Tor 0.4.3.6"
 	select FREETZ_LIB_libm if ! FREETZ_PACKAGE_TOR_STATIC
 	select FREETZ_LIB_libevent if ! FREETZ_PACKAGE_TOR_STATIC
 	select FREETZ_LIB_libcrypto if ! FREETZ_PACKAGE_TOR_STATIC

--- a/make/tor/tor.mk
+++ b/make/tor/tor.mk
@@ -1,6 +1,6 @@
-$(call PKG_INIT_BIN, 0.4.3.5)
+$(call PKG_INIT_BIN, 0.4.3.6)
 $(PKG)_SOURCE:=$(pkg)-$($(PKG)_VERSION).tar.gz
-$(PKG)_SOURCE_SHA256:=616a0e4ae688d0e151d46e3e4258565da4d443d1ddbd316db0b90910e2d5d868
+$(PKG)_SOURCE_SHA256:=6a2d0637d4e514be2ec574723a05065245cce51da78a21cec1dc831be5ccac62
 $(PKG)_SITE:=https://www.torproject.org/dist
 
 $(PKG)_BINARY:=$($(PKG)_DIR)/src/app/tor


### PR DESCRIPTION
Changelog: 
https://gitweb.torproject.org/tor.git/plain/ChangeLog?h=tor-0.4.3.6