### PR TITLE
wireguard: bump version

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -83,8 +83,8 @@ Latest changes:
     * spandsp 0.0.6pre21
     * squashfs-tools 3.4
     * squashfs-tools 4.3 (modified to support AVM-BE format)
-    * wireguard-tools 1.0.20200319
-    * wireguard-linux-compat 1.0.20200429
+    * wireguard-tools 1.0.20200820
+    * wireguard-linux-compat 1.0.20200729
     * xz 5.2.4
 
 - Updated tools and hooks:

--- a/make/wireguard-linux-compat/Config.in
+++ b/make/wireguard-linux-compat/Config.in
@@ -2,7 +2,7 @@ comment "WireGuard module (not available, needs replace kernel)"
 	depends on FREETZ_KERNEL_VERSION_3_10_MIN && !FREETZ_REPLACE_KERNEL && !FREETZ_AVM_HAS_CRYPTO_BLKCIPHER_BUILTIN
 
 config FREETZ_PACKAGE_WIREGUARD_LINUX_COMPAT
-	bool "wireguard-linux-compat 1.0.20200429"
+	bool "wireguard-linux-compat 1.0.20200729"
 	depends on FREETZ_KERNEL_VERSION_3_10_MIN && (FREETZ_AVM_HAS_CRYPTO_BLKCIPHER_BUILTIN || FREETZ_REPLACE_KERNEL) && FREETZ_REPLACE_MODULE_AVAILABLE
 	default n
 	select FREETZ_BUSYBOX_IP

--- a/make/wireguard-linux-compat/wireguard-linux-compat.mk
+++ b/make/wireguard-linux-compat/wireguard-linux-compat.mk
@@ -1,11 +1,12 @@
-$(call PKG_INIT_BIN, 1.0.20200429)
+$(call PKG_INIT_BIN, 1.0.20200729)
 $(PKG)_SOURCE:=wireguard-linux-compat-$($(PKG)_VERSION).tar.xz
+$(PKG)_SOURCE_SHA256:=690c7d9e115e2ff27386811cb495c9784678f717c8d6fc4cc7469dce373f252e
 $(PKG)_SITE:=https://git.zx2c4.com/wireguard-linux-compat/snapshot
 
 $(PKG)_MODULE:=$($(PKG)_DIR)/src/wireguard.ko
 $(PKG)_TARGET_MODULE:=$(KERNEL_MODULES_DIR)/drivers/net/wireguard/wireguard.ko
 
-$(PKG)_DEPENDS_ON += kernel 
+$(PKG)_DEPENDS_ON += kernel
 
 $(PKG)_REBUILD_SUBOPTS += FREETZ_KERNEL_VERSION
 
@@ -29,9 +30,9 @@ $(pkg):
 $(pkg)-precompiled: $($(PKG)_TARGET_MODULE)
 
 $(pkg)-clean:
-	-$(SUBMAKE) -C $(WIREGUARD_LINUX_COMPAT_DIR)/src clean 
+	-$(SUBMAKE) -C $(WIREGUARD_LINUX_COMPAT_DIR)/src clean
 
 $(pkg)-uninstall:
-	$(RM)  $(WIREGUARD_TARGET_MODULE) 
+	$(RM)  $(WIREGUARD_TARGET_MODULE)
 
 $(PKG_FINISH)

--- a/make/wireguard/Config.in
+++ b/make/wireguard/Config.in
@@ -2,7 +2,7 @@ comment "wireguard-tools (not available, needs replace kernel)"
 	depends on FREETZ_KERNEL_VERSION_3_10_MIN && !FREETZ_REPLACE_KERNEL && !FREETZ_AVM_HAS_CRYPTO_BLKCIPHER_BUILTIN
 
 config FREETZ_PACKAGE_WIREGUARD
-	bool "wireguard-tools 1.0.20200319"
+	bool "wireguard-tools 1.0.20200820"
 	depends on FREETZ_KERNEL_VERSION_3_10_MIN && (FREETZ_AVM_HAS_CRYPTO_BLKCIPHER_BUILTIN || FREETZ_REPLACE_KERNEL) && FREETZ_REPLACE_MODULE_AVAILABLE
 	default n
 	select FREETZ_BUSYBOX_IP

--- a/make/wireguard/wireguard.mk
+++ b/make/wireguard/wireguard.mk
@@ -1,6 +1,6 @@
-$(call PKG_INIT_BIN, 1.0.20200319)
+$(call PKG_INIT_BIN, 1.0.20200820)
 $(PKG)_SOURCE:=wireguard-tools-$($(PKG)_VERSION).tar.xz
-$(PKG)_SOURCE_SHA256:=757ed31d4d48d5fd7853bfd9bfa6a3a1b53c24a94fe617439948784a2c0ed987
+$(PKG)_SOURCE_SHA256:=7735a04c68fffb101a10a67e3bd97a171f2b8eb47e9ddce2be68eb6538b013d0
 $(PKG)_SITE:=https://git.zx2c4.com/wireguard-tools/snapshot
 
 $(PKG)_BINARY:=$($(PKG)_DIR)/src/wg


### PR DESCRIPTION
- wireguard-tools-1.0.20200820
- wireguard-linux-compat-1.0.20200729

Changelog:
- https://git.zx2c4.com/wireguard-tools/log/?h=v1.0.20200820
- https://git.zx2c4.com/wireguard-linux-compat/log/?h=v1.0.20200729