### PR TITLE
Tor: bump version to 0.4.4.5

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -199,7 +199,7 @@ Latest changes:
     * tinc 1.0.35/1.1pre17
     * tinyproxy 1.8.4
     * tmux 2.5
-    * tor 0.4.3.6
+    * tor 0.4.4.5
     * transmission 2.94
     * tree 1.8.0
     * uClibc++ 0.2.5-git

--- a/make/tor/Config.in
+++ b/make/tor/Config.in
@@ -1,5 +1,5 @@
 config FREETZ_PACKAGE_TOR
-	bool "Tor 0.4.3.6"
+	bool "Tor 0.4.4.5"
 	select FREETZ_LIB_libm if ! FREETZ_PACKAGE_TOR_STATIC
 	select FREETZ_LIB_libevent if ! FREETZ_PACKAGE_TOR_STATIC
 	select FREETZ_LIB_libcrypto if ! FREETZ_PACKAGE_TOR_STATIC

--- a/make/tor/patches/010-drop_backtrace_support.patch
+++ b/make/tor/patches/010-drop_backtrace_support.patch
@@ -1,6 +1,6 @@
 --- configure.ac
 +++ configure.ac
-@@ -659,8 +659,6 @@
+@@ -666,8 +666,6 @@
  	RtlSecureZeroMemory \
  	SecureZeroMemory \
  	accept4 \
@@ -11,7 +11,7 @@
  	timingsafe_memcmp \
 --- configure
 +++ configure
-@@ -8767,8 +8767,6 @@
+@@ -8785,8 +8785,6 @@
  	RtlSecureZeroMemory \
  	SecureZeroMemory \
  	accept4 \
@@ -20,7 +20,7 @@
  	eventfd \
  	explicit_bzero \
  	timingsafe_memcmp \
-@@ -12840,7 +12838,6 @@
+@@ -12858,7 +12856,6 @@
  		  unistd.h \
  		  arpa/inet.h \
  		  crt_externs.h \

--- a/make/tor/tor.mk
+++ b/make/tor/tor.mk
@@ -1,6 +1,6 @@
-$(call PKG_INIT_BIN, 0.4.3.6)
+$(call PKG_INIT_BIN, 0.4.4.5)
 $(PKG)_SOURCE:=$(pkg)-$($(PKG)_VERSION).tar.gz
-$(PKG)_SOURCE_SHA256:=6a2d0637d4e514be2ec574723a05065245cce51da78a21cec1dc831be5ccac62
+$(PKG)_SOURCE_SHA256:=a45ca00afe765e3baa839767c9dd6ac9a46dd01720a3a8ff4d86558c12359926
 $(PKG)_SITE:=https://www.torproject.org/dist
 
 $(PKG)_BINARY:=$($(PKG)_DIR)/src/app/tor


### PR DESCRIPTION
Changelog: 
https://gitweb.torproject.org/tor.git/plain/ChangeLog?h=tor-0.4.4.5