### PR TITLE
haproxy: bump version to 1.8.27

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -119,7 +119,7 @@ Latest changes:
     * gmp 6.1.2
     * gnu-make 4.2.1
     * gnutls 3.5.19
-    * haproxy 1.8.26
+    * haproxy 1.8.27
     * haserl 0.9.35
     * hplip 3.14.6
     * htop 1.0.3

--- a/make/haproxy/Config.in
+++ b/make/haproxy/Config.in
@@ -1,5 +1,5 @@
 config FREETZ_PACKAGE_HAPROXY
-	bool "HAProxy 1.8.26"
+	bool "HAProxy 1.8.27"
 	select FREETZ_LIB_libcrypt
 	select FREETZ_BUSYBOX_START_STOP_DAEMON
 	default n

--- a/make/haproxy/haproxy.mk
+++ b/make/haproxy/haproxy.mk
@@ -1,6 +1,6 @@
-$(call PKG_INIT_BIN, 1.8.26)
+$(call PKG_INIT_BIN, 1.8.27)
 $(PKG)_SOURCE:=$(pkg)-$($(PKG)_VERSION).tar.gz
-$(PKG)_SOURCE_SHA256:=e3c2a81b6f26dcb736a34ebb5f134d3251ceccf30386214655fa7ed6d3afa400
+$(PKG)_SOURCE_SHA256:=56ba6a21e13215fae56472ad37d5d68c3f19bde9da94c59e70b869eecf48bf50
 $(PKG)_SITE:=http://www.haproxy.org/download/1.8/src
 
 $(PKG)_BINARY:=$($(PKG)_DIR)/haproxy


### PR DESCRIPTION
CHANGELOG: https://www.haproxy.org/download/1.8/src/CHANGELOG