### PR TITLE
tor: bump version to 0.4.4.6

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -199,7 +199,7 @@ Latest changes:
     * tinc 1.0.35/1.1pre17
     * tinyproxy 1.8.4
     * tmux 2.5
-    * tor 0.4.4.5
+    * tor 0.4.4.6
     * transmission 2.94
     * tree 1.8.0
     * uClibc++ 0.2.5-git

--- a/make/tor/Config.in
+++ b/make/tor/Config.in
@@ -1,5 +1,5 @@
 config FREETZ_PACKAGE_TOR
-	bool "Tor 0.4.4.5"
+	bool "Tor 0.4.4.6"
 	select FREETZ_LIB_libm if ! FREETZ_PACKAGE_TOR_STATIC
 	select FREETZ_LIB_libevent if ! FREETZ_PACKAGE_TOR_STATIC
 	select FREETZ_LIB_libcrypto if ! FREETZ_PACKAGE_TOR_STATIC

--- a/make/tor/tor.mk
+++ b/make/tor/tor.mk
@@ -1,6 +1,6 @@
-$(call PKG_INIT_BIN, 0.4.4.5)
+$(call PKG_INIT_BIN, 0.4.4.6)
 $(PKG)_SOURCE:=$(pkg)-$($(PKG)_VERSION).tar.gz
-$(PKG)_SOURCE_SHA256:=a45ca00afe765e3baa839767c9dd6ac9a46dd01720a3a8ff4d86558c12359926
+$(PKG)_SOURCE_SHA256:=5f154c155803adf5c89e87cab53017b6908c5ebe50c65839e8cf4fbd2abe1fdc
 $(PKG)_SITE:=https://www.torproject.org/dist
 
 $(PKG)_BINARY:=$($(PKG)_DIR)/src/app/tor


### PR DESCRIPTION
Changelog:
https://gitweb.torproject.org/tor.git/plain/ChangeLog?h=tor-0.4.4.6