### PR TITLE
dnsmasq: bump version to 2.84rc2

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -105,7 +105,7 @@ Latest changes:
     * curl 7.72.0
     * davfs2 1.5.2
     * dbus 1.8.20
-    * dnsmasq 2.83
+    * dnsmasq 2.84rc2
     * dosfstools 3.0.28
     * dropbear 2020.81
     * e2fsprogs 1.42.13

--- a/make/dnsmasq/Config.in
+++ b/make/dnsmasq/Config.in
@@ -1,5 +1,5 @@
 config FREETZ_PACKAGE_DNSMASQ
-	bool "Dnsmasq 2.83"
+	bool "Dnsmasq 2.84rc2"
 	depends on FREETZ_TARGET_IPV6_SUPPORT
 	default n
 	help

--- a/make/dnsmasq/dnsmasq.mk
+++ b/make/dnsmasq/dnsmasq.mk
@@ -1,7 +1,7 @@
-$(call PKG_INIT_BIN, 2.83)
+$(call PKG_INIT_BIN, 2.84rc2)
 $(PKG)_SOURCE:=$(pkg)-$($(PKG)_VERSION).tar.xz
-$(PKG)_SOURCE_SHA256:=ffc1f7e8b05e22d910b9a71d09f1128197292766dc7c54cb7018a1b2c3af4aea
-$(PKG)_SITE:=http://thekelleys.org.uk/dnsmasq
+$(PKG)_SOURCE_SHA256:=e76ff2e75da4ce5191c89e7393de218c75732a5feb454ed43b320eb17dd66581
+$(PKG)_SITE:=http://thekelleys.org.uk/dnsmasq/release-candidates
 #$(PKG)_SITE:=git://thekelleys.org.uk/dnsmasq.git
 
 $(PKG)_STARTLEVEL=40 # multid-wrapper may start it earlier!


### PR DESCRIPTION
Changes: http://thekelleys.org.uk/gitweb/?p=dnsmasq.git;a=summary
Ist nur ein RC, aber löst erstmal das Problem mit dem loggen von "failed to send packet: Network is unreachable"
Sobald 2.84 released wurde, erstelle ich einen neuen PR.