### PR TITLE
cacerts: bump version to 2021-01-19

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -47,7 +47,7 @@ Latest changes:
     * avm-forwarding 0.0.1
     * axTLS wrapper 1.4.9
     * bvi 1.4.0
-    * CA certificates 2020-10-14
+    * CA certificates 2021-01-19
     * cntlm 0.93beta5
     * decrypt FRITZ!OS configs v0.2 (renamed version of PeterPawn's script decode_passwords)
     * ISC dhcp 4.3.6-P1

--- a/make/cacerts/Config.in
+++ b/make/cacerts/Config.in
@@ -1,5 +1,5 @@
 config FREETZ_PACKAGE_CACERTS
-	bool "CA Certs 2020-10-14"
+	bool "CA Certs 2021-01-19"
 	default n
 	help
 		This package provides up-to-date ca-certs from curl.haxx.se

--- a/make/cacerts/cacerts.mk
+++ b/make/cacerts/cacerts.mk
@@ -1,6 +1,6 @@
-$(call PKG_INIT_BIN, 2020-10-14)
+$(call PKG_INIT_BIN, 2021-01-19)
 $(PKG)_SOURCE:=cacert-$($(PKG)_VERSION).pem
-$(PKG)_SOURCE_SHA256:=bb28d145ed1a4ee67253d8ddb11268069c9dafe3db25a9eee654974c4e43eee5
+$(PKG)_SOURCE_SHA256:=e010c0c071a2c79a76aa3c289dc7e4ac4ed38492bfda06d766a80b707ebd2f29
 $(PKG)_SITE:=https://curl.haxx.se/ca
 
 $(PKG)_BINARY:=$(DL_DIR)/$($(PKG)_SOURCE)


### PR DESCRIPTION
Mozilla extract from curl https://curl.se/docs/caextract.html